### PR TITLE
Improve error output of `FindLayerWithPath` when path not found

### DIFF
--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -78,7 +78,12 @@ func AssertError(t *testing.T, actual error, expected string) {
 		t.Fatalf("Expected an error but got nil")
 	}
 	if !strings.Contains(actual.Error(), expected) {
-		t.Fatalf(`Expected error to contain "%s", got "%s"`, expected, actual.Error())
+		t.Fatalf(
+			`Expected error to contain "%s", got "%s"\n\n Diff:\n%s`,
+			expected,
+			actual.Error(),
+			cmp.Diff(expected, actual.Error()),
+		)
 	}
 }
 


### PR DESCRIPTION
This PR is strictly cosmetic. Previously, the output of the layers when a path was not found resulted in a lot of extra whitespace and slightly cluttered output.

This PR condenses the output of the error and adds additional information to assist troubleshooting such as symlinks and filetypes. 

**Notice:** this only impacts `fakes` which is intended for testing.

**Before**
```
Could not find /buildpacks/buildpack-1-id/buildpack-1-version-1s in any layer. 
 
 layer dirs.tar --- 
 Contents: 

 
layer lifecycle.tar --- 
 Contents: 
/cnb/lifecycle/analyzer 
/cnb/lifecycle/builder 
/cnb/lifecycle/cacher 
/cnb/lifecycle/detector 
/cnb/lifecycle/exporter 
/cnb/lifecycle/launcher 
/cnb/lifecycle/restorer 

 
layer buildpack-1-id.buildpack-1-version-1.tar --- 
 Contents: 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/bin/build 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/bin/detect 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/buildpack.toml 

 
layer buildpack-1-id.buildpack-1-version-2.tar --- 
 Contents: 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-2/bin/build 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-2/bin/detect 
/cnb/buildpacks/buildpack-1-id/buildpack-1-version-2/buildpack.toml 


...
 
```

**After**

```
could not find '/buildpacks/buildpack-1-id/buildpack-1-version-1s' in any layer.
                
Layers
-------
dirs.tar
  - [D] /workspace
  - [D] /layers
  - [D] /cnb
  - [D] /cnb/buildpacks
  - [D] /platform
  - [D] /platform/env

lifecycle.tar
  - [D] /cnb/lifecycle
  - [F] /cnb/lifecycle/analyzer
  - [F] /cnb/lifecycle/builder
  - [F] /cnb/lifecycle/cacher
  - [F] /cnb/lifecycle/detector
  - [F] /cnb/lifecycle/exporter
  - [F] /cnb/lifecycle/launcher
  - [F] /cnb/lifecycle/restorer

buildpack-1-id.buildpack-1-version-1.tar
  - [D] /cnb/buildpacks/buildpack-1-id
  - [D] /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1
  - [D] /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/bin
  - [F] /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/bin/build
  - [F] /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/bin/detect
  - [F] /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1/buildpack.toml

...

compat.tar
  - [S] /lifecycle -> /cnb/lifecycle
  - [D] /buildpacks
  - [D] /buildpacks/buildpack-1-id
  - [S] /buildpacks/buildpack-1-id/buildpack-1-version-1 -> /cnb/buildpacks/buildpack-1-id/buildpack-1-version-1
  - [D] /buildpacks/buildpack-1-id
  - [S] /buildpacks/buildpack-1-id/buildpack-1-version-2 -> /cnb/buildpacks/buildpack-1-id/buildpack-1-version-2
  - [D] /buildpacks/buildpack-2-id
  - [S] /buildpacks/buildpack-2-id/buildpack-2-version-1 -> /cnb/buildpacks/buildpack-2-id/buildpack-2-version-1
  - [F] /buildpacks/stack.toml

env.tar
  (empty)
```