### PR TITLE
Reproducibility

### DIFF
--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -1,0 +1,155 @@
+package acceptance
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+	"time"
+
+	dockerclient "github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/imgutil"
+	"github.com/buildpacks/imgutil/local"
+	"github.com/buildpacks/imgutil/remote"
+	h "github.com/buildpacks/imgutil/testhelpers"
+)
+
+var registryPort string
+
+func newTestImageName() string {
+	return "localhost:" + registryPort + "/imgutil-acceptance-" + h.RandString(10)
+}
+
+func TestAcceptance(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	dockerRegistry := h.NewDockerRegistry()
+	dockerRegistry.Start(t)
+	defer dockerRegistry.Stop(t)
+
+	registryPort = dockerRegistry.Port
+
+	spec.Run(t, "Reproducibility", testReproducibility, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+func testReproducibility(t *testing.T, when spec.G, it spec.S) {
+	var (
+		imageName1, imageName2 string
+		mutateAndSave          func(t *testing.T, image imgutil.Image)
+		dockerClient           *dockerclient.Client
+	)
+
+	it.Before(func() {
+		dockerClient = h.DockerCli(t)
+
+		imageName1 = newTestImageName()
+		imageName2 = newTestImageName()
+		labelKey := "label-key-" + h.RandString(10)
+		labelVal := "label-val-" + h.RandString(10)
+		envKey := "env-key-" + h.RandString(10)
+		envVal := "env-val-" + h.RandString(10)
+		workingDir := "working-dir-" + h.RandString(10)
+		layer1 := randomLayer(t)
+		layer2 := randomLayer(t)
+
+		mutateAndSave = func(t *testing.T, img imgutil.Image) {
+			h.AssertNil(t, img.AddLayer(layer1))
+			h.AssertNil(t, img.AddLayer(layer2))
+			h.AssertNil(t, img.SetLabel(labelKey, labelVal))
+			h.AssertNil(t, img.SetEnv(envKey, envVal))
+			h.AssertNil(t, img.SetEntrypoint("some", "entrypoint"))
+			h.AssertNil(t, img.SetCmd("some", "cmd"))
+			h.AssertNil(t, img.SetWorkingDir(workingDir))
+			h.AssertNil(t, img.Save())
+		}
+	})
+
+	it.After(func() {
+		// clean up any local images
+		h.DockerRmi(dockerClient, imageName1)
+		h.DockerRmi(dockerClient, imageName2)
+	})
+
+	it("remote/remote", func() {
+		img1, err := remote.NewImage(imageName1, authn.DefaultKeychain, remote.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img1)
+
+		img2, err := remote.NewImage(imageName2, authn.DefaultKeychain, remote.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img2)
+
+		compare(t, imageName1, imageName2)
+	})
+
+	it("local/local", func() {
+		img1, err := local.NewImage(imageName1, dockerClient, local.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img1)
+		h.PushImage(dockerClient, imageName1)
+
+		img2, err := local.NewImage(imageName2, dockerClient, local.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img2)
+		h.PushImage(dockerClient, imageName2)
+
+		compare(t, imageName1, imageName2)
+	})
+
+	it("remote/local", func() {
+		img1, err := remote.NewImage(imageName1, authn.DefaultKeychain, remote.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img1)
+
+		img2, err := local.NewImage(imageName2, dockerClient, local.FromBaseImage("busybox"))
+		h.AssertNil(t, err)
+		mutateAndSave(t, img2)
+		h.PushImage(dockerClient, imageName2)
+
+		compare(t, imageName1, imageName2)
+	})
+}
+
+func randomLayer(t *testing.T) string {
+	tr, err := h.CreateSingleFileTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10))
+	h.AssertNil(t, err)
+
+	tarFile, err := ioutil.TempFile("", "add-layer-test")
+	h.AssertNil(t, err)
+	defer tarFile.Close()
+
+	_, err = io.Copy(tarFile, tr)
+	h.AssertNil(t, err)
+	return tarFile.Name()
+}
+
+func compare(t *testing.T, img1, img2 string) {
+	ref1, err := name.ParseReference(img1, name.WeakValidation)
+	h.AssertNil(t, err)
+
+	ref2, err := name.ParseReference(img2, name.WeakValidation)
+	h.AssertNil(t, err)
+
+	v1img1, err := ggcrremote.Image(ref1)
+	h.AssertNil(t, err)
+
+	v1img2, err := ggcrremote.Image(ref2)
+	h.AssertNil(t, err)
+
+	cfg1, err := v1img1.ConfigFile()
+	h.AssertNil(t, err)
+
+	cfg2, err := v1img2.ConfigFile()
+	h.AssertNil(t, err)
+
+	h.AssertEq(t, cfg1, cfg2)
+
+	h.AssertEq(t, ref1.Identifier(), ref2.Identifier())
+}

--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -90,6 +90,7 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it("local/local", func() {
+		h.AssertNil(t, h.PullImage(dockerClient, "busybox"))
 		img1, err := local.NewImage(imageName1, dockerClient, local.FromBaseImage("busybox"))
 		h.AssertNil(t, err)
 		mutateAndSave(t, img1)
@@ -108,6 +109,7 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 		h.AssertNil(t, err)
 		mutateAndSave(t, img1)
 
+		h.AssertNil(t, h.PullImage(dockerClient, "busybox"))
 		img2, err := local.NewImage(imageName2, dockerClient, local.FromBaseImage("busybox"))
 		h.AssertNil(t, err)
 		mutateAndSave(t, img2)

--- a/image.go
+++ b/image.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var NormalizedDateTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
+
 type SaveDiagnostic struct {
 	ImageName string
 	Cause     error

--- a/local/local.go
+++ b/local/local.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
 
@@ -419,16 +420,11 @@ func (i *Image) doSave() (types.ImageInspect, error) {
 }
 
 func (i *Image) newConfigFile() ([]byte, error) {
-	imgConfig := map[string]interface{}{
-		"os":      "linux",
-		"created": time.Now().Format(time.RFC3339),
-		"config":  i.inspect.Config,
-		"rootfs": map[string][]string{
-			"diff_ids": i.inspect.RootFS.Layers,
-		},
-		"history": make([]struct{}, len(i.inspect.RootFS.Layers)),
+	cfg, err := v1Config(i.inspect)
+	if err != nil {
+		return nil, err
 	}
-	return json.Marshal(imgConfig)
+	return json.Marshal(cfg)
 }
 
 func (i *Image) Delete() error {
@@ -613,4 +609,76 @@ func defaultInspect() types.ImageInspect {
 	return types.ImageInspect{
 		Config: &container.Config{},
 	}
+}
+
+func v1Config(inspect types.ImageInspect) (v1.ConfigFile, error) {
+	history := make([]v1.History, len(inspect.RootFS.Layers))
+	for i, _ := range history {
+		// zero history
+		history[i] = v1.History{
+			Created: v1.Time{Time: imgutil.NormalizedDateTime},
+		}
+	}
+	diffIDs := make([]v1.Hash, len(inspect.RootFS.Layers))
+	for i, layer := range inspect.RootFS.Layers {
+		hash, err := v1.NewHash(layer)
+		if err != nil {
+			return v1.ConfigFile{}, err
+		}
+		diffIDs[i] = hash
+	}
+	exposedPorts := make(map[string]struct{}, len(inspect.Config.ExposedPorts))
+	for key, val := range inspect.Config.ExposedPorts {
+		exposedPorts[string(key)] = val
+	}
+	var config v1.Config
+	if inspect.Config != nil {
+		var healthcheck *v1.HealthConfig
+		if inspect.Config.Healthcheck != nil {
+			healthcheck = &v1.HealthConfig{
+				Test:        inspect.Config.Healthcheck.Test,
+				Interval:    inspect.Config.Healthcheck.Interval,
+				Timeout:     inspect.Config.Healthcheck.Timeout,
+				StartPeriod: inspect.Config.Healthcheck.StartPeriod,
+				Retries:     inspect.Config.Healthcheck.Retries,
+			}
+		}
+		config = v1.Config{
+			AttachStderr:    inspect.Config.AttachStderr,
+			AttachStdin:     inspect.Config.AttachStdin,
+			AttachStdout:    inspect.Config.AttachStdout,
+			Cmd:             inspect.Config.Cmd,
+			Healthcheck:     healthcheck,
+			Domainname:      inspect.Config.Domainname,
+			Entrypoint:      inspect.Config.Entrypoint,
+			Env:             inspect.Config.Env,
+			Hostname:        inspect.Config.Hostname,
+			Image:           inspect.Config.Image,
+			Labels:          inspect.Config.Labels,
+			OnBuild:         inspect.Config.OnBuild,
+			OpenStdin:       inspect.Config.OpenStdin,
+			StdinOnce:       inspect.Config.StdinOnce,
+			Tty:             inspect.Config.Tty,
+			User:            inspect.Config.User,
+			Volumes:         inspect.Config.Volumes,
+			WorkingDir:      inspect.Config.WorkingDir,
+			ExposedPorts:    exposedPorts,
+			ArgsEscaped:     inspect.Config.ArgsEscaped,
+			NetworkDisabled: inspect.Config.NetworkDisabled,
+			MacAddress:      inspect.Config.MacAddress,
+			StopSignal:      inspect.Config.StopSignal,
+			Shell:           inspect.Config.Shell,
+		}
+	}
+	return v1.ConfigFile{
+		Architecture: inspect.Architecture,
+		Created:      v1.Time{Time: imgutil.NormalizedDateTime},
+		History:      history,
+		OS:           inspect.Os,
+		RootFS: v1.RootFS{
+			Type:    "layers",
+			DiffIDs: diffIDs,
+		},
+		Config: config,
+	}, nil
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -623,12 +623,29 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#Save", func() {
 		when("image exists", func() {
+			var tarPath string
+
 			it.Before(func() {
 				h.CreateImageOnRemote(t, dockerClient, repoName, fmt.Sprintf(`
 					FROM busybox
 					LABEL repo_name_for_randomisation=%s
 					LABEL mykey=oldValue
 				`, repoName), nil)
+
+				tarFile, err := ioutil.TempFile("", "add-layer-test")
+				h.AssertNil(t, err)
+				defer tarFile.Close()
+
+				tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
+				h.AssertNil(t, err)
+
+				_, err = io.Copy(tarFile, tr)
+				h.AssertNil(t, err)
+				tarPath = tarFile.Name()
+			})
+
+			it.After(func() {
+				os.Remove(tarPath)
 			})
 
 			it("can be pulled by digest", func() {
@@ -649,30 +666,27 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 
 			})
 
-			it("updates the createdAt time", func() {
-				h.AssertNil(t, h.PullImage(dockerClient, repoName))
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-				h.AssertNil(t, err)
-
-				originalCreatedAtTime := inspect.Created
-
+			it("zeroes all times and client specific fields", func() {
 				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
+
+				h.AssertNil(t, img.AddLayer(tarPath))
 
 				h.AssertNil(t, img.Save())
 
 				h.AssertNil(t, h.PullImage(dockerClient, repoName))
-				inspect, _, err = dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
-				originalTime, err := time.Parse(time.RFC3339Nano, originalCreatedAtTime)
-				h.AssertNil(t, err)
+				h.AssertEq(t, inspect.Created, imgutil.NormalizedDateTime.Format(time.RFC3339))
+				h.AssertEq(t, inspect.Container, "")
+				h.AssertEq(t, inspect.DockerVersion, "")
 
-				newTime, err := time.Parse(time.RFC3339Nano, inspect.Created)
+				history, err := dockerClient.ImageHistory(context.TODO(), repoName)
 				h.AssertNil(t, err)
-
-				if !originalTime.Before(newTime) {
-					t.Fatalf("the new createdAt time %s was not after the original createdAt time %s", inspect.Created, originalCreatedAtTime)
+				h.AssertEq(t, len(history), len(inspect.RootFS.Layers))
+				for _, item := range history {
+					h.AssertEq(t, item.Created, imgutil.NormalizedDateTime.Unix())
 				}
 			})
 		})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -675,6 +675,7 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 
 				h.AssertNil(t, h.PullImage(dockerClient, repoName))
+				defer h.DockerRmi(dockerClient, repoName)
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -168,7 +168,7 @@ func CreateImageOnRemote(t *testing.T, dockerCli *dockercli.Client, repoName, do
 		topLayer = "N/A"
 	}
 
-	AssertNil(t, pushImage(dockerCli, repoName))
+	AssertNil(t, PushImage(dockerCli, repoName))
 
 	return topLayer
 }
@@ -234,7 +234,7 @@ func CopySingleFileFromImage(dockerCli *dockercli.Client, repoName, path string)
 	return CopySingleFileFromContainer(dockerCli, ctr.ID, path)
 }
 
-func pushImage(dockerCli *dockercli.Client, ref string) error {
+func PushImage(dockerCli *dockercli.Client, ref string) error {
 	rc, err := dockerCli.ImagePush(context.Background(), ref, dockertypes.ImagePushOptions{RegistryAuth: "{}"})
 	if err != nil {
 		return err


### PR DESCRIPTION
Attempts to make builds reproducible (excluding in-layer file times which are handled by the consumer of this library right now).

This gets us a step closer to a refactor that would allow us to use more vanilla ggcr vs. custom interfaces. But I didn't do the larger refactor in this PR.