### PR TITLE
Use the interface rather than the concret type

### DIFF
--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -43,7 +43,7 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 	var (
 		imageName1, imageName2 string
 		mutateAndSave          func(t *testing.T, image imgutil.Image)
-		dockerClient           *dockerclient.Client
+		dockerClient           dockerclient.CommonAPIClient
 	)
 
 	it.Before(func() {

--- a/local/local.go
+++ b/local/local.go
@@ -27,7 +27,7 @@ import (
 
 type Image struct {
 	repoName         string
-	docker           *client.Client
+	docker           client.CommonAPIClient
 	inspect          types.ImageInspect
 	layerPaths       []string
 	currentTempImage string
@@ -73,7 +73,7 @@ func FromBaseImage(imageName string) ImageOption {
 	}
 }
 
-func NewImage(repoName string, dockerClient *client.Client, ops ...ImageOption) (imgutil.Image, error) {
+func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...ImageOption) (imgutil.Image, error) {
 	inspect := defaultInspect()
 
 	image := &Image{
@@ -451,7 +451,7 @@ func (i *Image) downloadImageOnce(imageName string) (*FileSystemLocalImage, erro
 	return v.(*FileSystemLocalImage), nil
 }
 
-func downloadImage(docker *client.Client, imageName string) (*FileSystemLocalImage, error) {
+func downloadImage(docker client.CommonAPIClient, imageName string) (*FileSystemLocalImage, error) {
 	ctx := context.Background()
 
 	tarFile, err := docker.ImageSave(ctx, []string{imageName})
@@ -588,7 +588,7 @@ func untar(r io.Reader, dest string) error {
 	}
 }
 
-func inspectOptionalImage(docker *client.Client, imageName string) (types.ImageInspect, error) {
+func inspectOptionalImage(docker client.CommonAPIClient, imageName string) (types.ImageInspect, error) {
 	var (
 		err     error
 		inspect types.ImageInspect

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -42,7 +42,7 @@ func newTestImageName() string {
 }
 
 func testLocalImage(t *testing.T, when spec.G, it spec.S) {
-	var dockerClient *client.Client
+	var dockerClient client.CommonAPIClient
 
 	it.Before(func() {
 		var err error

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -45,7 +45,7 @@ func TestRemoteImage(t *testing.T) {
 
 func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 	var repoName string
-	var dockerClient *client.Client
+	var dockerClient client.CommonAPIClient
 
 	it.Before(func() {
 		var err error
@@ -863,7 +863,7 @@ func manifestLayers(t *testing.T, repoName string) []string {
 	return outSlice
 }
 
-func remoteLabel(t *testing.T, dockerCli *client.Client, repoName, label string) string {
+func remoteLabel(t *testing.T, dockerCli client.CommonAPIClient, repoName, label string) string {
 	t.Helper()
 
 	h.AssertNil(t, h.PullImage(dockerCli, repoName))


### PR DESCRIPTION
I'd like to be able to provide a `dockerclient.CommonAPIClient` to `pack` rather than a `*dockerclient.Client`

Signed-off-by: David Gageot <david@gageot.net>