### PR TITLE
Refactor tests not rely on Dockerfile FROM scratch

### DIFF
--- a/local/local_test.go
+++ b/local/local_test.go
@@ -82,14 +82,13 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("returns the local image", func() {
-					labels := make(map[string]string)
-					labels["some.label"] = "some.value"
+					baseImage, err := local.NewImage(repoName, dockerClient)
+					h.AssertNil(t, err)
 
-					h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-							FROM scratch
-							LABEL repo_name_for_randomisation=%s
-							ENV MY_VAR=my_val
-							`, repoName), labels)
+					h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+					h.AssertNil(t, baseImage.SetEnv("MY_VAR", "my_val"))
+					h.AssertNil(t, baseImage.SetLabel("some.label", "some.value"))
+					h.AssertNil(t, baseImage.Save())
 
 					localImage, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 					h.AssertNil(t, err)
@@ -133,11 +132,13 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-					LABEL mykey=myvalue other=data
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetLabel("mykey", "myvalue"))
+				h.AssertNil(t, baseImage.SetLabel("other", "data"))
+				h.AssertNil(t, baseImage.Save())
 			})
 
 			it.After(func() {
@@ -180,11 +181,12 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-					ENV MY_VAR=my_val
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetEnv("MY_VAR", "my_val"))
+				h.AssertNil(t, baseImage.Save())
 			})
 
 			it.After(func() {
@@ -264,10 +266,11 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+			baseImage, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+			h.AssertNil(t, baseImage.Save())
 		})
 
 		it.After(func() {
@@ -333,11 +336,12 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		when("image has labels", func() {
 			it.Before(func() {
 				var err error
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-					LABEL some-key=some-value
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetLabel("some-key", "some-value"))
+				h.AssertNil(t, baseImage.Save())
 
 				img, err = local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 				h.AssertNil(t, err)
@@ -364,10 +368,11 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		when("no labels exists", func() {
 			it.Before(func() {
 				var err error
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					CMD ['/usr/bin/run']
-				`), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetCmd("/usr/bin/run"))
+				h.AssertNil(t, baseImage.Save())
 
 				img, err = local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 				h.AssertNil(t, err)
@@ -401,11 +406,13 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 		it.Before(func() {
 			var err error
-			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-					LABEL some-key=some-value
-				`, repoName), nil)
+			baseImage, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+			h.AssertNil(t, baseImage.SetLabel("some-key", "some-value"))
+			h.AssertNil(t, baseImage.Save())
+
 			img, err = local.NewImage(repoName, dockerClient)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -436,10 +443,12 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 		it.Before(func() {
 			var err error
-			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+			baseImage, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+			h.AssertNil(t, baseImage.Save())
+
 			img, err = local.NewImage(repoName, dockerClient)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -470,10 +479,12 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 		it.Before(func() {
 			var err error
-			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+			baseImage, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+			h.AssertNil(t, baseImage.Save())
+
 			img, err = local.NewImage(repoName, dockerClient)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -505,10 +516,12 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+			baseImage, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+			h.AssertNil(t, baseImage.Save())
+
 			img, err = local.NewImage(repoName, dockerClient)
 			h.AssertNil(t, err)
 			origID = h.ImageID(t, repoName)
@@ -630,10 +643,10 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			)
 			it.Before(func() {
 				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-				FROM busybox
-				LABEL repo_name_for_randomisation=%s
-				RUN echo old-base > base.txt
-				RUN echo text-old-base > otherfile.txt
+					FROM busybox
+					LABEL repo_name_for_randomisation=%s
+					RUN echo old-base > base.txt
+					RUN echo text-old-base > otherfile.txt
 				`, repoName), nil)
 
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
@@ -676,10 +689,10 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 		it.Before(func() {
 			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM busybox
-					LABEL repo_name_for_randomisation=%s
-					RUN echo -n old-layer > old-layer.txt
-				`, repoName), nil)
+				FROM busybox
+				LABEL repo_name_for_randomisation=%s
+				RUN echo -n old-layer > old-layer.txt
+			`, repoName), nil)
 			tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
 			h.AssertNil(t, err)
 			tarFile, err := ioutil.TempFile("", "add-layer-test")
@@ -730,10 +743,10 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 		)
 		it.Before(func() {
 			h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM busybox
-					LABEL repo_name_for_randomisation=%s
-					RUN echo -n old-layer > old-layer.txt
-				`, repoName), nil)
+				FROM busybox
+				LABEL repo_name_for_randomisation=%s
+				RUN echo -n old-layer > old-layer.txt
+			`, repoName), nil)
 			tr, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
 			h.AssertNil(t, err)
 			tarFile, err := ioutil.TempFile("", "add-layer-test")
@@ -801,6 +814,7 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 				r, err := img.GetLayer(topLayer)
 				h.AssertNil(t, err)
 				tr := tar.NewReader(r)
+
 				header, err := tr.Next()
 				h.AssertNil(t, err)
 				h.AssertEq(t, header.Name, "dir/")
@@ -824,10 +838,9 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM busybox
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient, local.FromBaseImage("busybox"))
+				h.AssertNil(t, err)
+				h.AssertNil(t, baseImage.Save())
 			})
 
 			it.After(func() {
@@ -937,11 +950,14 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 
 			it.Before(func() {
 				var err error
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM busybox
-					LABEL repo_name_for_randomisation=%s
-					LABEL mykey=oldValue
-				`, repoName), nil)
+
+				baseImage, err := local.NewImage(repoName, dockerClient, local.FromBaseImage("busybox"))
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetLabel("mykey", "oldValue"))
+				h.AssertNil(t, baseImage.Save())
+
 				origID = h.ImageID(t, repoName)
 
 				img, err = local.NewImage(repoName, dockerClient)
@@ -1088,10 +1104,11 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM scratch
-					LABEL repo_name_for_randomisation=%s
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.Save())
 			})
 
 			it.After(func() {
@@ -1135,11 +1152,13 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 
 			it.Before(func() {
 				var err error
-				h.CreateImageOnLocal(t, dockerClient, repoName, fmt.Sprintf(`
-					FROM busybox
-					LABEL repo_name_for_randomisation=%s
-					LABEL mykey=oldValue
-				`, repoName), nil)
+				baseImage, err := local.NewImage(repoName, dockerClient, local.FromBaseImage("busybox"))
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetLabel("mykey", "oldValue"))
+				h.AssertNil(t, baseImage.Save())
+
 				origImg, err = local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -781,11 +781,7 @@ func testLocalImage(t *testing.T, when spec.G, it spec.S) {
 			it.Before(func() {
 				var err error
 
-				existingImage, err := local.NewImage(
-					repoName,
-					dockerClient,
-					local.FromBaseImage("busybox"),
-				)
+				existingImage, err := local.NewImage(repoName, dockerClient)
 
 				h.AssertNil(t, existingImage.SetLabel("repo_name_for_randomisation", repoName))
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -188,19 +188,22 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			var (
 				img imgutil.Image
 			)
+
 			it.Before(func() {
 				var err error
-				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				baseImageName := newTestImageName()
+
+				baseImage, err := remote.NewImage(baseImageName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
-				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))
+				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", baseImageName))
 				h.AssertNil(t, baseImage.SetEnv("MY_VAR", "my_val"))
 				h.AssertNil(t, baseImage.Save())
 
 				img, err = remote.NewImage(
 					repoName,
 					authn.DefaultKeychain,
-					remote.FromBaseImage(repoName),
+					remote.FromBaseImage(baseImageName),
 				)
 				h.AssertNil(t, err)
 			})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -699,7 +699,6 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 				prevImage, err := remote.NewImage(
 					prevImageName,
 					authn.DefaultKeychain,
-					remote.FromBaseImage("busybox"),
 				)
 				h.AssertNil(t, err)
 
@@ -772,11 +771,7 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			var tarPath string
 
 			it.Before(func() {
-				baseImage, err := remote.NewImage(
-					repoName,
-					authn.DefaultKeychain,
-					remote.FromBaseImage("busybox"),
-				)
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, baseImage.SetLabel("repo_name_for_randomisation", repoName))


### PR DESCRIPTION
- Also Replace some "FROM busybox" examples that didn't need "RUN"
- Purpose: changed to ease porting to Windows since Windows daemons do not support FROM scratch
- Benefit: Tests are less coupled to Dockerfile and run faster
- Potential downsides: tests now depend more on imgutil methods instead of Dockerfiles and docker daemon impl to create test images but it's unlikely Dockerfile and imgutil functionality will be out of sync in a way that shouldn't be fixed as a bug

Signed-off-by: Micah Young <ymicah@vmware.com>

Note: in upcoming Windows PRs, the remaining `FROM busybox` that have `RUN <command>` will get cleaned up as well, but the cleanup doesn't make much sense in this stand-alone commit.