### PR TITLE
Add support for Windows images

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - windows-linux-images #remove from PR
   pull_request:
     branches:
       - master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,13 +4,24 @@ on:
   push:
     branches:
       - master
+      - windows-linux-images #remove from PR
   pull_request:
     branches:
       - master
 
 jobs:
-  test-and-build:
+  test-and-build-linux:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: '1.13'
+      - name: Test
+        run: make test
+  test-and-build-windows:
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - name: Set up go

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: test
 
 install-goimports:
 	@echo "> Installing goimports..."
-	cd tools; $(GOCMD) install golang.org/x/tools/cmd/goimports
+	cd tools && $(GOCMD) install golang.org/x/tools/cmd/goimports
 
 format: install-goimports
 	@echo "> Formating code..."
@@ -14,7 +14,7 @@ format: install-goimports
 
 install-golangci-lint:
 	@echo "> Installing golangci-lint..."
-	cd tools; $(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd tools && $(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 lint: install-golangci-lint
 	@echo "> Linting code..."

--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -67,8 +67,12 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 		envKey := "env-key-" + h.RandString(10)
 		envVal := "env-val-" + h.RandString(10)
 		workingDir := "working-dir-" + h.RandString(10)
-		layer1 = randomLayer(t, daemonOS)
-		layer2 = randomLayer(t, daemonOS)
+
+		layer1, err = h.CreateSingleFileBaseLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), daemonOS)
+		h.AssertNil(t, err)
+
+		layer2, err = h.CreateSingleFileLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), daemonOS)
+		h.AssertNil(t, err)
 
 		mutateAndSave = func(t *testing.T, img imgutil.Image) {
 			h.AssertNil(t, img.AddLayer(layer1))
@@ -130,13 +134,6 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 
 		compare(t, imageName1, imageName2)
 	})
-}
-
-func randomLayer(t *testing.T, os string) string {
-	tarPath, err := h.CreateSingleFileLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), h.LayerOption(os))
-	h.AssertNil(t, err)
-
-	return tarPath
 }
 
 func compare(t *testing.T, img1, img2 string) {

--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -68,7 +68,7 @@ func testReproducibility(t *testing.T, when spec.G, it spec.S) {
 		envVal := "env-val-" + h.RandString(10)
 		workingDir := "working-dir-" + h.RandString(10)
 
-		layer1, err = h.CreateSingleFileBaseLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), daemonOS)
+		layer1, err = h.CreateSingleFileLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), daemonOS)
 		h.AssertNil(t, err)
 
 		layer2, err = h.CreateSingleFileLayerTar(fmt.Sprintf("/new-layer-%s.txt", h.RandString(10)), "new-layer-"+h.RandString(10), daemonOS)

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -61,6 +61,14 @@ func (i *Image) Label(key string) (string, error) {
 	return i.labels[key], nil
 }
 
+func (i *Image) OS() (string, error) {
+	return "linux", nil
+}
+
+func (i *Image) Architecture() (string, error) {
+	return "amd64", nil
+}
+
 func (i *Image) Rename(name string) {
 	i.name = name
 }

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -31,6 +31,7 @@ func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 		createdAt:     time.Now(),
 		savedNames:    map[string]bool{},
 		os:            "linux",
+		osVersion:     "",
 		architecture:  "amd64",
 	}
 }
@@ -67,11 +68,15 @@ func (i *Image) Label(key string) (string, error) {
 }
 
 func (i *Image) OS() (string, error) {
-	return "linux", nil
+	return i.os, nil
+}
+
+func (i *Image) OSVersion() (string, error) {
+	return i.os, nil
 }
 
 func (i *Image) Architecture() (string, error) {
-	return "amd64", nil
+	return i.architecture, nil
 }
 
 func (i *Image) Rename(name string) {

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -30,6 +30,8 @@ func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 		prevLayersMap: map[string]string{},
 		createdAt:     time.Now(),
 		savedNames:    map[string]bool{},
+		os:            "linux",
+		architecture:  "amd64",
 	}
 }
 
@@ -42,6 +44,9 @@ type Image struct {
 	labels        map[string]string
 	env           map[string]string
 	topLayerSha   string
+	os            string
+	osVersion     string
+	architecture  string
 	identifier    imgutil.Identifier
 	name          string
 	entryPoint    []string
@@ -239,6 +244,12 @@ func (i *Image) Found() bool {
 
 func (i *Image) SetIdentifier(identifier imgutil.Identifier) {
 	i.identifier = identifier
+}
+
+func (i *Image) SetPlatform(os, osVersion, architecture string) {
+	i.os = os
+	i.osVersion = osVersion
+	i.architecture = architecture
 }
 
 func (i *Image) Cleanup() error {

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -36,7 +36,7 @@ func TestFake(t *testing.T) {
 }
 
 func testFake(t *testing.T, when spec.G, it spec.S) {
-	it("implements imgutil.Image", func(){
+	it("implements imgutil.Image", func() {
 		var _ imgutil.Image = fakes.NewImage("", "", nil)
 	})
 

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -36,6 +36,10 @@ func TestFake(t *testing.T) {
 }
 
 func testFake(t *testing.T, when spec.G, it spec.S) {
+	it("implements imgutil.Image", func(){
+		var _ imgutil.Image = fakes.NewImage("", "", nil)
+	})
+
 	when("#SavedNames", func() {
 		when("additional names are provided during save", func() {
 			var (

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,7 @@ golang.org/x/tools v0.0.0-20200210192313-1ace956b0e17/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/image.go
+++ b/image.go
@@ -51,6 +51,8 @@ type Image interface {
 	Delete() error
 	CreatedAt() (time.Time, error)
 	Identifier() (Identifier, error)
+	OS() (string, error)
+	Architecture() (string, error)
 }
 
 type Identifier fmt.Stringer

--- a/image.go
+++ b/image.go
@@ -52,6 +52,7 @@ type Image interface {
 	CreatedAt() (time.Time, error)
 	Identifier() (Identifier, error)
 	OS() (string, error)
+	OSVersion() (string, error)
 	Architecture() (string, error)
 }
 

--- a/local/local.go
+++ b/local/local.go
@@ -75,7 +75,12 @@ func FromBaseImage(imageName string) ImageOption {
 }
 
 func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...ImageOption) (imgutil.Image, error) {
-	inspect := defaultInspect()
+	var err error
+
+	inspect, err := defaultInspect(dockerClient)
+	if err != nil {
+		return nil, err
+	}
 
 	image := &Image{
 		docker:       dockerClient,
@@ -85,7 +90,6 @@ func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...Image
 		downloadOnce: &sync.Once{},
 	}
 
-	var err error
 	for _, v := range ops {
 		image, err = v(image)
 		if err != nil {
@@ -109,6 +113,14 @@ func (i *Image) Env(key string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func (i *Image) OS() (string, error) {
+	return i.inspect.Os, nil
+}
+
+func (i *Image) Architecture() (string, error) {
+	return i.inspect.Architecture, nil
 }
 
 func (i *Image) Rename(name string) {
@@ -608,7 +620,7 @@ func inspectOptionalImage(docker client.CommonAPIClient, imageName string) (type
 
 	if inspect, _, err = docker.ImageInspectWithRaw(context.Background(), imageName); err != nil {
 		if client.IsErrNotFound(err) {
-			return defaultInspect(), nil
+			return types.ImageInspect{}, nil
 		}
 
 		return types.ImageInspect{}, errors.Wrapf(err, "verifying image '%s'", imageName)
@@ -617,12 +629,18 @@ func inspectOptionalImage(docker client.CommonAPIClient, imageName string) (type
 	return inspect, nil
 }
 
-func defaultInspect() types.ImageInspect {
+func defaultInspect(docker client.CommonAPIClient) (types.ImageInspect, error) {
+	daemonInfo, err := docker.Info(context.Background())
+	if err != nil {
+		return types.ImageInspect{}, err
+	}
+
 	return types.ImageInspect{
-		Os:           "linux",
+		Os:           daemonInfo.OSType,
+		OsVersion:    daemonInfo.OSVersion,
 		Architecture: "amd64",
 		Config:       &container.Config{},
-	}
+	}, nil
 }
 
 func v1Config(inspect types.ImageInspect) (v1.ConfigFile, error) {
@@ -689,6 +707,7 @@ func v1Config(inspect types.ImageInspect) (v1.ConfigFile, error) {
 		Created:      v1.Time{Time: imgutil.NormalizedDateTime},
 		History:      history,
 		OS:           inspect.Os,
+		OSVersion:    inspect.OsVersion,
 		RootFS: v1.RootFS{
 			Type:    "layers",
 			DiffIDs: diffIDs,

--- a/local/local.go
+++ b/local/local.go
@@ -119,6 +119,10 @@ func (i *Image) OS() (string, error) {
 	return i.inspect.Os, nil
 }
 
+func (i *Image) OSVersion() (string, error) {
+	return i.inspect.OsVersion, nil
+}
+
 func (i *Image) Architecture() (string, error) {
 	return i.inspect.Architecture, nil
 }

--- a/local/local.go
+++ b/local/local.go
@@ -620,7 +620,7 @@ func inspectOptionalImage(docker client.CommonAPIClient, imageName string) (type
 
 	if inspect, _, err = docker.ImageInspectWithRaw(context.Background(), imageName); err != nil {
 		if client.IsErrNotFound(err) {
-			return types.ImageInspect{}, nil
+			return defaultInspect(docker)
 		}
 
 		return types.ImageInspect{}, errors.Wrapf(err, "verifying image '%s'", imageName)

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -607,7 +607,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			it("switches the base", func() {
 				// Before
-				txt, err := h.CopySingleFileFromImage(dockerClient, repoName, "/base.txt")
+				txt, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "/base.txt")
 				h.AssertNil(t, err)
 				h.AssertEq(t, txt, "old-base")
 
@@ -717,7 +717,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 				defer h.DockerRmi(dockerClient, repoName)
 
-				output, err := h.CopySingleFileFromImage(dockerClient, repoName, "new-layer.txt")
+				output, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "new-layer.txt")
 				h.AssertNil(t, err)
 				h.AssertEq(t, output, "new-layer")
 			})
@@ -758,11 +758,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 				defer h.DockerRmi(dockerClient, repoName)
 
-				output, err := h.CopySingleFileFromImage(dockerClient, repoName, "old-layer.txt")
+				output, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "old-layer.txt")
 				h.AssertNil(t, err)
 				h.AssertEq(t, output, "old-layer")
 
-				output, err = h.CopySingleFileFromImage(dockerClient, repoName, "new-layer.txt")
+				output, err = h.CopySingleFileFromLocalImage(dockerClient, repoName, "new-layer.txt")
 				h.AssertNil(t, err)
 				h.AssertEq(t, output, "new-layer")
 			})
@@ -817,11 +817,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, img.AddLayerWithDiffID(newLayerPath, diffID))
 			h.AssertNil(t, img.Save())
 
-			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "old-layer.txt")
+			output, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "old-layer.txt")
 			h.AssertNil(t, err)
 			h.AssertEq(t, output, "old-layer")
 
-			output, err = h.CopySingleFileFromImage(dockerClient, repoName, "new-layer.txt")
+			output, err = h.CopySingleFileFromLocalImage(dockerClient, repoName, "new-layer.txt")
 			h.AssertNil(t, err)
 			h.AssertEq(t, output, "new-layer")
 		})
@@ -965,12 +965,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "layer-2.txt")
+			output, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "layer-2.txt")
 			h.AssertNil(t, err)
 			h.AssertEq(t, output, "old-layer-2")
 
 			// Confirm layer-1.txt does not exist
-			_, err = h.CopySingleFileFromImage(dockerClient, repoName, "layer-1.txt")
+			_, err = h.CopySingleFileFromLocalImage(dockerClient, repoName, "layer-1.txt")
 			h.AssertMatch(t, err.Error(), regexp.MustCompile(`Error: No such container:path: .*:layer-1.txt`))
 		})
 
@@ -987,12 +987,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "layer-1.txt")
+			output, err := h.CopySingleFileFromLocalImage(dockerClient, repoName, "layer-1.txt")
 			h.AssertNil(t, err)
 			h.AssertEq(t, output, "old-layer-1")
 
 			// Confirm layer-2.txt does not exist
-			_, err = h.CopySingleFileFromImage(dockerClient, repoName, "layer-2.txt")
+			_, err = h.CopySingleFileFromLocalImage(dockerClient, repoName, "layer-2.txt")
 			h.AssertMatch(t, err.Error(), regexp.MustCompile(`Error: No such container:path: .*:layer-2.txt`))
 		})
 	})

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -149,10 +149,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("uses the base image architecture", func() {
 					armBaseImageName := "arm64v8/busybox@sha256:50edf1d080946c6a76989d1c3b0e753b62f7d9b5f5e66e88bef23ebbd1e9709c"
 					expectedArmArch := "arm64"
+					expectedOSVersion := ""
 					if daemonOS == "windows" {
 						// this nanoserver windows/arm image exists and pulls. Not sure whether it works for anything else.
 						armBaseImageName = "mcr.microsoft.com/windows/nanoserver@sha256:29e2270953589a12de7a77a7e77d39e3b3e9cdfd243c922b3b8a63e2d8a71026"
 						expectedArmArch = "arm"
+						expectedOSVersion = "10.0.17763.1040"
 					}
 
 					h.PullImage(dockerClient, armBaseImageName)
@@ -164,8 +166,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					imgArch, err := img.Architecture()
 					h.AssertNil(t, err)
-
 					h.AssertEq(t, imgArch, expectedArmArch)
+
+					imgOSVersion, err := img.OSVersion()
+					h.AssertNil(t, err)
+					h.AssertEq(t, imgOSVersion, expectedOSVersion)
 				})
 			})
 		})

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -35,7 +35,12 @@ func WithPreviousImage(imageName string) ImageOption {
 	return func(r *Image) (*Image, error) {
 		var err error
 
-		prevImage, err := newV1Image(r.keychain, imageName)
+		currentImagePlatform, err := imagePlatform(r.image)
+		if err != nil {
+			return nil, err
+		}
+
+		prevImage, err := newV1Image(r.keychain, imageName, currentImagePlatform)
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +58,34 @@ func WithPreviousImage(imageName string) ImageOption {
 func FromBaseImage(imageName string) ImageOption {
 	return func(r *Image) (*Image, error) {
 		var err error
-		r.image, err = newV1Image(r.keychain, imageName)
+
+		currentImagePlatform, err := imagePlatform(r.image)
+		if err != nil {
+			return nil, err
+		}
+
+		r.image, err = newV1Image(r.keychain, imageName, currentImagePlatform)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+}
+
+func WithDefaultPlatform(p v1.Platform) ImageOption {
+	return func(r *Image) (*Image, error) {
+		var err error
+		cfg := &v1.ConfigFile{}
+		if p.OS != "" {
+			cfg.OS = p.OS
+		}
+		if p.Architecture != "" {
+			cfg.Architecture = p.Architecture
+		}
+		if p.OSVersion != "" {
+			cfg.OSVersion = p.OSVersion
+		}
+		r.image, err = mutate.ConfigFile(r.image, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -83,12 +115,12 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (img
 	return ri, nil
 }
 
-func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
+func newV1Image(keychain authn.Keychain, repoName string, fallbackPlatform v1.Platform) (v1.Image, error) {
 	ref, auth, err := referenceForRepoName(keychain, repoName)
 	if err != nil {
 		return nil, err
 	}
-	image, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	descriptor, err := remote.Get(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {
 			switch transportErr.Errors[0].Code {
@@ -98,13 +130,43 @@ func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
 		}
 		return nil, fmt.Errorf("connect to repo store '%s': %s", repoName, err.Error())
 	}
+
+	var image v1.Image
+	switch descriptor.MediaType {
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		image, err = descriptor.Image()
+		if err != nil {
+			return nil, err
+		}
+	case types.OCIImageIndex, types.DockerManifestList:
+		image, err = remote.Image(ref, remote.WithPlatform(fallbackPlatform), remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown descriptor response type for ref: %s => %s", repoName, descriptor.MediaType)
+	}
+
 	return image, nil
+}
+
+func imagePlatform(image v1.Image) (v1.Platform, error) {
+	configFile, err := image.ConfigFile()
+	if err != nil {
+		return v1.Platform{}, err
+	}
+
+	return v1.Platform{
+		Architecture: configFile.Architecture,
+		OS:           configFile.OS,
+		OSVersion:    configFile.OSVersion,
+	}, nil
 }
 
 func emptyImage() (v1.Image, error) {
 	cfg := &v1.ConfigFile{
-		Architecture: "amd64",
 		OS:           "linux",
+		Architecture: "amd64",
 		RootFS: v1.RootFS{
 			Type:    "layers",
 			DiffIDs: []v1.Hash{},
@@ -148,6 +210,22 @@ func (i *Image) Env(key string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func (i *Image) OS() (string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil || cfg.OS == "" {
+		return "", fmt.Errorf("failed to get OS from config file for image '%s'", i.repoName)
+	}
+	return cfg.OS, nil
+}
+
+func (i *Image) Architecture() (string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil || cfg.Architecture == "" {
+		return "", fmt.Errorf("failed to get Architecture from config file for image '%s'", i.repoName)
+	}
+	return cfg.Architecture, nil
 }
 
 func (i *Image) Rename(name string) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -35,12 +35,7 @@ func WithPreviousImage(imageName string) ImageOption {
 	return func(r *Image) (*Image, error) {
 		var err error
 
-		currentImagePlatform, err := imagePlatform(r.image)
-		if err != nil {
-			return nil, err
-		}
-
-		prevImage, err := newV1Image(r.keychain, imageName, currentImagePlatform)
+		prevImage, err := newV1Image(r.keychain, imageName)
 		if err != nil {
 			return nil, err
 		}
@@ -59,33 +54,7 @@ func FromBaseImage(imageName string) ImageOption {
 	return func(r *Image) (*Image, error) {
 		var err error
 
-		currentImagePlatform, err := imagePlatform(r.image)
-		if err != nil {
-			return nil, err
-		}
-
-		r.image, err = newV1Image(r.keychain, imageName, currentImagePlatform)
-		if err != nil {
-			return nil, err
-		}
-		return r, nil
-	}
-}
-
-func WithDefaultPlatform(p v1.Platform) ImageOption {
-	return func(r *Image) (*Image, error) {
-		var err error
-		cfg := &v1.ConfigFile{}
-		if p.OS != "" {
-			cfg.OS = p.OS
-		}
-		if p.Architecture != "" {
-			cfg.Architecture = p.Architecture
-		}
-		if p.OSVersion != "" {
-			cfg.OSVersion = p.OSVersion
-		}
-		r.image, err = mutate.ConfigFile(r.image, cfg)
+		r.image, err = newV1Image(r.keychain, imageName)
 		if err != nil {
 			return nil, err
 		}
@@ -115,12 +84,13 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (img
 	return ri, nil
 }
 
-func newV1Image(keychain authn.Keychain, repoName string, fallbackPlatform v1.Platform) (v1.Image, error) {
+func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
 	ref, auth, err := referenceForRepoName(keychain, repoName)
 	if err != nil {
 		return nil, err
 	}
-	descriptor, err := remote.Get(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+
+	image, err := remote.Image(ref, remote.WithPlatform(defaultQueryPlatform()), remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {
 			switch transportErr.Errors[0].Code {
@@ -131,36 +101,14 @@ func newV1Image(keychain authn.Keychain, repoName string, fallbackPlatform v1.Pl
 		return nil, fmt.Errorf("connect to repo store '%s': %s", repoName, err.Error())
 	}
 
-	var image v1.Image
-	switch descriptor.MediaType {
-	case types.OCIManifestSchema1, types.DockerManifestSchema2:
-		image, err = descriptor.Image()
-		if err != nil {
-			return nil, err
-		}
-	case types.OCIImageIndex, types.DockerManifestList:
-		image, err = remote.Image(ref, remote.WithPlatform(fallbackPlatform), remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("unknown descriptor response type for ref: %s => %s", repoName, descriptor.MediaType)
-	}
-
 	return image, nil
 }
 
-func imagePlatform(image v1.Image) (v1.Platform, error) {
-	configFile, err := image.ConfigFile()
-	if err != nil {
-		return v1.Platform{}, err
-	}
-
+func defaultQueryPlatform() v1.Platform {
 	return v1.Platform{
-		Architecture: configFile.Architecture,
-		OS:           configFile.OS,
-		OSVersion:    configFile.OSVersion,
-	}, nil
+		OS:           "linux",
+		Architecture: "amd64",
+	}
 }
 
 func emptyImage() (v1.Image, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -90,7 +90,7 @@ func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
 		return nil, err
 	}
 
-	image, err := remote.Image(ref, remote.WithPlatform(defaultQueryPlatform()), remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	image, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {
 			switch transportErr.Errors[0].Code {
@@ -102,13 +102,6 @@ func newV1Image(keychain authn.Keychain, repoName string) (v1.Image, error) {
 	}
 
 	return image, nil
-}
-
-func defaultQueryPlatform() v1.Platform {
-	return v1.Platform{
-		OS:           "linux",
-		Architecture: "amd64",
-	}
 }
 
 func emptyImage() (v1.Image, error) {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -168,6 +168,14 @@ func (i *Image) OS() (string, error) {
 	return cfg.OS, nil
 }
 
+func (i *Image) OSVersion() (string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil {
+		return "", fmt.Errorf("failed to get OSVersion from config file for image '%s'", i.repoName)
+	}
+	return cfg.OSVersion, nil
+}
+
 func (i *Image) Architecture() (string, error) {
 	cfg, err := i.image.ConfigFile()
 	if err != nil || cfg == nil || cfg.Architecture == "" {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -619,16 +619,16 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("appends a layer", func() {
-			newLayerPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", daemonOS)
-			h.AssertNil(t, err)
-			defer os.Remove(newLayerPath)
-
 			img, err := remote.NewImage(
 				repoName,
 				ggcrauthn.DefaultKeychain,
 				remote.FromBaseImage(repoName),
 			)
 			h.AssertNil(t, err)
+
+			newLayerPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", daemonOS)
+			h.AssertNil(t, err)
+			defer os.Remove(newLayerPath)
 
 			err = img.AddLayer(newLayerPath)
 			h.AssertNil(t, err)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	ggcrauthn "github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -44,13 +44,13 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#NewRemote", func() {
 		when("no base image is given", func() {
 			it("returns an empty image", func() {
-				_, err := remote.NewImage(newTestImageName(), ggcrauthn.DefaultKeychain)
+				_, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
 				h.AssertNil(t, err)
 			})
 
 			it("sets sensible defaults for all required fields", func() {
 				// os, architecture, and rootfs are required per https://github.com/opencontainers/image-spec/blob/master/config.md
-				img, err := remote.NewImage(newTestImageName(), ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
 
@@ -76,7 +76,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := remote.NewImage(
 						repoName,
-						ggcrauthn.DefaultKeychain,
+						authn.DefaultKeychain,
 						remote.FromBaseImage(baseImageName),
 					)
 					h.AssertNil(t, err)
@@ -104,7 +104,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := remote.NewImage(
 						repoName,
-						ggcrauthn.DefaultKeychain,
+						authn.DefaultKeychain,
 						remote.FromBaseImage(baseImageName),
 					)
 					h.AssertNil(t, err)
@@ -133,7 +133,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 						img, err := remote.NewImage(
 							repoName,
-							ggcrauthn.DefaultKeychain,
+							authn.DefaultKeychain,
 							remote.FromBaseImage(manifestListName),
 						)
 						h.AssertNil(t, err)
@@ -161,7 +161,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("don't error", func() {
 					_, err := remote.NewImage(
 						repoName,
-						ggcrauthn.DefaultKeychain,
+						authn.DefaultKeychain,
 						remote.FromBaseImage("some-bad-repo-name"),
 					)
 
@@ -175,7 +175,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("don't error", func() {
 					_, err := remote.NewImage(
 						repoName,
-						ggcrauthn.DefaultKeychain,
+						authn.DefaultKeychain,
 						remote.WithPreviousImage("some-bad-repo-name"),
 					)
 
@@ -188,7 +188,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#Label", func() {
 		when("image exists", func() {
 			it.Before(func() {
-				baseImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, baseImage.SetLabel("mykey", "myvalue"))
@@ -197,7 +197,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns the label value", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				label, err := img.Label("mykey")
@@ -206,7 +206,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns an empty string for a missing label", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				label, err := img.Label("missing-label")
@@ -217,7 +217,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("image is empty", func() {
 			it("returns an empty label", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				label, err := img.Label("some-label")
@@ -232,14 +232,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			var baseImageName = newTestImageName()
 
 			it.Before(func() {
-				baseImage, err := remote.NewImage(baseImageName, ggcrauthn.DefaultKeychain)
+				baseImage, err := remote.NewImage(baseImageName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, baseImage.SetEnv("MY_VAR", "my_val"))
 				h.AssertNil(t, baseImage.Save())
 			})
 
 			it("returns the label value", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(baseImageName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(baseImageName))
 				h.AssertNil(t, err)
 
 				val, err := img.Env("MY_VAR")
@@ -248,7 +248,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns an empty string for a missing label", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(baseImageName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(baseImageName))
 				h.AssertNil(t, err)
 
 				val, err := img.Env("MISSING_VAR")
@@ -259,7 +259,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("image is empty", func() {
 			it("returns an empty string", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				val, err := img.Env("SOME_VAR")
@@ -271,7 +271,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#Name", func() {
 		it("always returns the original name", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 			h.AssertNil(t, err)
 			h.AssertEq(t, img.Name(), repoName)
 		})
@@ -280,7 +280,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#CreatedAt", func() {
 		const reference = "busybox@sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4"
 		it("returns the containers created at time", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(reference))
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(reference))
 			h.AssertNil(t, err)
 
 			expectedTime := time.Date(2019, 4, 2, 23, 32, 10, 727183061, time.UTC)
@@ -296,7 +296,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("returns a digest reference", func() {
 			img, err := remote.NewImage(
 				repoName+":some-tag",
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 				remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 			)
 			h.AssertNil(t, err)
@@ -309,7 +309,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("accurately parses the reference for an image with a sha", func() {
 			img, err := remote.NewImage(
 				repoName+"@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5",
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 				remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 			)
 			h.AssertNil(t, err)
@@ -323,7 +323,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns the new digest reference", func() {
 				img, err := remote.NewImage(
 					repoName+":some-tag",
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 				)
 				h.AssertNil(t, err)
@@ -337,7 +337,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				testImg, err := remote.NewImage(
 					"test",
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.FromBaseImage(id.String()),
 				)
 				h.AssertNil(t, err)
@@ -353,7 +353,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#SetLabel", func() {
 		when("image exists", func() {
 			it("sets label on img object", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, img.SetLabel("mykey", "new-val"))
@@ -363,7 +363,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("saves label", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, img.SetLabel("mykey", "new-val"))
@@ -372,7 +372,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				testImg, err := remote.NewImage(
 					"test",
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.FromBaseImage(repoName),
 				)
 				h.AssertNil(t, err)
@@ -387,7 +387,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEnv", func() {
 		it("sets the environment", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetEnv("ENV_KEY", "ENV_VAL")
@@ -402,7 +402,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetWorkingDir", func() {
 		it("sets the environment", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetWorkingDir("/some/work/dir")
@@ -417,7 +417,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetEntrypoint", func() {
 		it("sets the entrypoint", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetEntrypoint("some", "entrypoint")
@@ -432,7 +432,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#SetCmd", func() {
 		it("sets the cmd", func() {
-			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetCmd("some", "cmd")
@@ -460,7 +460,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				defer os.Remove(newBaseLayer2Path)
 
-				newBaseImage, err := remote.NewImage(newBase, ggcrauthn.DefaultKeychain)
+				newBaseImage, err := remote.NewImage(newBase, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = newBaseImage.AddLayer(newBaseLayer1Path)
@@ -483,7 +483,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				defer os.Remove(oldBaseLayer2Path)
 
-				oldBaseImage, err := remote.NewImage(oldBase, ggcrauthn.DefaultKeychain)
+				oldBaseImage, err := remote.NewImage(oldBase, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = oldBaseImage.AddLayer(oldBaseLayer1Path)
@@ -508,7 +508,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				defer os.Remove(origLayer2Path)
 
-				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(oldBase))
+				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(oldBase))
 				h.AssertNil(t, err)
 
 				err = origImage.AddLayer(origLayer1Path)
@@ -531,9 +531,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				)
 
 				// Run rebase
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
-				newBaseImg, err := remote.NewImage(newBase, ggcrauthn.DefaultKeychain, remote.FromBaseImage(newBase))
+				newBaseImg, err := remote.NewImage(newBase, authn.DefaultKeychain, remote.FromBaseImage(newBase))
 				h.AssertNil(t, err)
 				err = img.Rebase(oldTopLayerDiffID, newBaseImg)
 				h.AssertNil(t, err)
@@ -562,7 +562,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				expectedTopLayerDiffID, err := h.FileDiffID(topLayerPath)
 				h.AssertNil(t, err)
 
-				existingImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
+				existingImage, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				err = existingImage.AddLayer(baseLayerPath)
@@ -573,7 +573,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, existingImage.Save())
 
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				actualTopLayerDiffID, err := img.TopLayer()
@@ -585,7 +585,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("the image has no layers", func() {
 			it("returns an error", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				_, err = img.TopLayer()
@@ -598,7 +598,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("appends a layer", func() {
 			existingImage, err := remote.NewImage(
 				repoName,
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 			)
 			h.AssertNil(t, err)
 
@@ -611,7 +611,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, existingImage.Save())
 			img, err := remote.NewImage(
 				repoName,
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 				remote.FromBaseImage(repoName),
 			)
 			h.AssertNil(t, err)
@@ -639,7 +639,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("appends a layer", func() {
 			existingImage, err := remote.NewImage(
 				repoName,
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 			)
 			h.AssertNil(t, err)
 
@@ -653,7 +653,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			img, err := remote.NewImage(
 				repoName,
-				ggcrauthn.DefaultKeychain,
+				authn.DefaultKeychain,
 				remote.FromBaseImage(repoName),
 			)
 			h.AssertNil(t, err)
@@ -691,7 +691,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				prevImageName = "localhost:" + registryPort + "/pack-image-test-" + h.RandString(10)
 				prevImage, err := remote.NewImage(
 					prevImageName,
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 				)
 				h.AssertNil(t, err)
 
@@ -715,7 +715,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("reuses a layer", func() {
 				img, err := remote.NewImage(
 					repoName,
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.WithPreviousImage(prevImageName),
 				)
 				h.AssertNil(t, err)
@@ -744,7 +744,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns error on nonexistent layer", func() {
 				img, err := remote.NewImage(
 					repoName,
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.WithPreviousImage(prevImageName),
 				)
 				h.AssertNil(t, err)
@@ -761,7 +761,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#Save", func() {
 		when("image exists", func() {
 			it("can be pulled by digest", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = img.SetLabel("mykey", "newValue")
@@ -774,7 +774,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				testImg, err := remote.NewImage(
 					"test",
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.FromBaseImage(identifier.String()),
 				)
 				h.AssertNil(t, err)
@@ -786,7 +786,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("zeroes all times and client specific fields", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				tarPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", "linux")
@@ -822,12 +822,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			)
 
 			it("saves to multiple names", func() {
-				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, image.Save(additionalRepoNames...))
 				for _, n := range successfulRepoNames {
-					testImg, err := remote.NewImage(n, ggcrauthn.DefaultKeychain)
+					testImg, err := remote.NewImage(n, authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, testImg.Found(), true)
 				}
@@ -837,7 +837,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("returns results with errors for those that failed", func() {
 					failingName := newTestImageName() + ":🧨"
 
-					image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+					image, err := remote.NewImage(repoName, authn.DefaultKeychain)
 					h.AssertNil(t, err)
 
 					err = image.Save(append([]string{failingName}, additionalRepoNames...)...)
@@ -851,7 +851,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(t, saveErr.Errors[0].Cause, "could not parse reference")
 
 					for _, n := range successfulRepoNames {
-						testImg, err := remote.NewImage(n, ggcrauthn.DefaultKeychain)
+						testImg, err := remote.NewImage(n, authn.DefaultKeychain)
 						h.AssertNil(t, err)
 						h.AssertEq(t, testImg.Found(), true)
 					}
@@ -863,11 +863,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#Found", func() {
 		when("it exists", func() {
 			it("returns true, nil", func() {
-				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, origImage.Save())
 
-				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, image.Found(), true)
@@ -876,7 +876,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("it does not exist", func() {
 			it("returns false, nil", func() {
-				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, image.Found(), false)
@@ -888,14 +888,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		when("it exists", func() {
 			var img imgutil.Image
 			it("returns nil and is deleted", func() {
-				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, origImage.SetLabel("some-label", "some-val"))
 				h.AssertNil(t, origImage.Save())
 
 				img, err = remote.NewImage(
 					repoName,
-					ggcrauthn.DefaultKeychain,
+					authn.DefaultKeychain,
 					remote.FromBaseImage(repoName),
 				)
 
@@ -910,7 +910,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("it does not exists", func() {
 			it("returns an error", func() {
-				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, img.Found(), false)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2,19 +2,17 @@ package remote_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/google/go-containerregistry/pkg/authn"
+	ggcrauthn "github.com/google/go-containerregistry/pkg/authn"
+	ggcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -42,67 +40,176 @@ func TestRemote(t *testing.T) {
 }
 
 func testImage(t *testing.T, when spec.G, it spec.S) {
-	var repoName string
-	var dockerClient client.CommonAPIClient
+	var (
+		repoName              string
+		dockerClient          client.CommonAPIClient
+		runnableBaseImageName string
+		daemonOS              string
+	)
 
 	it.Before(func() {
 		var err error
 		dockerClient = h.DockerCli(t)
-		h.AssertNil(t, err)
 		repoName = newTestImageName()
+
+		daemonInfo, err := dockerClient.Info(context.TODO())
+		h.AssertNil(t, err)
+
+		daemonOS = daemonInfo.OSType
+
+		runnableBaseImageName = h.RunnableBaseImage(daemonOS)
+
+		h.AssertNil(t, h.PullImage(dockerClient, runnableBaseImageName))
 	})
 
 	when("#NewRemote", func() {
 		when("no base image is given", func() {
 			it("returns an empty image", func() {
-				_, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
+				_, err := remote.NewImage(newTestImageName(), ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 			})
 
 			it("sets sensible defaults for all required fields", func() {
 				// os, architecture, and rootfs are required per https://github.com/opencontainers/image-spec/blob/master/config.md
-				img, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
+				img, err := remote.NewImage(newTestImageName(), ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
-				h.AssertNil(t, h.PullImage(dockerClient, img.Name()))
-				defer h.DockerRmi(dockerClient, img.Name())
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+
+				os, err := img.OS()
 				h.AssertNil(t, err)
-				h.AssertEq(t, inspect.Os, "linux")
-				h.AssertEq(t, inspect.Architecture, "amd64")
-				h.AssertEq(t, inspect.RootFS.Type, "layers")
+				h.AssertEq(t, os, "linux")
+
+				arch, err := img.Architecture()
+				h.AssertNil(t, err)
+				h.AssertEq(t, arch, "amd64")
+			})
+		})
+
+		when("#WithDefaultPlatform", func() {
+			when("no base image is given", func() {
+				it("sets os and architecture", func() {
+					img, err := remote.NewImage(
+						repoName,
+						ggcrauthn.DefaultKeychain,
+						remote.WithDefaultPlatform(
+							ggcrv1.Platform{OS: "windows", Architecture: "arm"}),
+					)
+					h.AssertNil(t, err)
+					h.AssertNil(t, img.Save())
+
+					os, err := img.OS()
+					h.AssertNil(t, err)
+					h.AssertEq(t, os, "windows")
+
+					arch, err := img.Architecture()
+					h.AssertNil(t, err)
+					h.AssertEq(t, arch, "arm")
+				})
 			})
 		})
 
 		when("#FromRemoteBaseImage", func() {
 			when("base image exists", func() {
-				var (
-					baseName         = "busybox"
-					err              error
-					existingLayerSha string
-				)
+				it("sets the initial state from a linux/arm base image", func() {
+					baseImageName := "arm64v8/busybox@sha256:50edf1d080946c6a76989d1c3b0e753b62f7d9b5f5e66e88bef23ebbd1e9709c"
+					existingLayerSha := "sha256:5a0b973aa300cd2650869fd76d8546b361fcd6dfc77bd37b9d4f082cca9874e4"
 
-				it.Before(func() {
-					err = h.PullImage(dockerClient, baseName)
-					h.AssertNil(t, err)
-
-					inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), baseName)
-					h.AssertNil(t, err)
-
-					existingLayerSha = inspect.RootFS.Layers[0]
-				})
-
-				it("sets the initial state to match the base image", func() {
 					img, err := remote.NewImage(
 						repoName,
-						authn.DefaultKeychain,
-						remote.FromBaseImage(baseName),
+						ggcrauthn.DefaultKeychain,
+						remote.FromBaseImage(baseImageName),
 					)
 					h.AssertNil(t, err)
+
+					os, err := img.OS()
+					h.AssertNil(t, err)
+					h.AssertEq(t, os, "linux")
+
+					arch, err := img.Architecture()
+					h.AssertNil(t, err)
+					h.AssertEq(t, arch, "arm64")
 
 					readCloser, err := img.GetLayer(existingLayerSha)
 					h.AssertNil(t, err)
 					defer readCloser.Close()
+				})
+
+				it("sets the initial state from a windows/amd64 base image", func() {
+					baseImageName := "mcr.microsoft.com/windows/nanoserver@sha256:06281772b6a561411d4b338820d94ab1028fdeb076c85350bbc01e80c4bfa2b4"
+					existingLayerSha := "sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e"
+
+					img, err := remote.NewImage(
+						repoName,
+						ggcrauthn.DefaultKeychain,
+						remote.FromBaseImage(baseImageName),
+					)
+					h.AssertNil(t, err)
+
+					os, err := img.OS()
+					h.AssertNil(t, err)
+					h.AssertEq(t, os, "windows")
+
+					arch, err := img.Architecture()
+					h.AssertNil(t, err)
+					h.AssertEq(t, arch, "amd64")
+
+					readCloser, err := img.GetLayer(existingLayerSha)
+					h.AssertNil(t, err)
+					defer readCloser.Close()
+				})
+
+				when("base image is a multi-OS/Arch manifest list", func() {
+					it("returns a base image matching the runtime GOOS/GOARCH", func() {
+						manifestListName := "golang:1.13.8"
+						existingLayerSha := "sha256:427da4a135b0869c1a274ba38e23d45bdbda93134c4ad99c8900cb0cfe9f0c9e"
+
+						img, err := remote.NewImage(
+							repoName,
+							ggcrauthn.DefaultKeychain,
+							remote.FromBaseImage(manifestListName),
+						)
+						h.AssertNil(t, err)
+
+						os, err := img.OS()
+						h.AssertNil(t, err)
+						h.AssertEq(t, os, "linux")
+
+						arch, err := img.Architecture()
+						h.AssertNil(t, err)
+						h.AssertEq(t, arch, "amd64")
+
+						readCloser, err := img.GetLayer(existingLayerSha)
+						h.AssertNil(t, err)
+						defer readCloser.Close()
+					})
+
+					when("and WithDefaultPlatform is set to windows/amd64", func() {
+						it("returns a base image matching the runtime GOOS/GOARCH", func() {
+							manifestListName := "golang:1.13.8"
+							existingLayerSha := "sha256:cba908afa240240fceb312eb682bd7660fd5a404ddfd22843852dfdef141314b"
+
+							img, err := remote.NewImage(
+								repoName,
+								ggcrauthn.DefaultKeychain,
+								remote.WithDefaultPlatform(
+									ggcrv1.Platform{OS: "windows", Architecture: "amd64"}),
+								remote.FromBaseImage(manifestListName),
+							)
+							h.AssertNil(t, err)
+
+							os, err := img.OS()
+							h.AssertNil(t, err)
+							h.AssertEq(t, os, "windows")
+
+							arch, err := img.Architecture()
+							h.AssertNil(t, err)
+							h.AssertEq(t, arch, "amd64")
+
+							readCloser, err := img.GetLayer(existingLayerSha)
+							h.AssertNil(t, err)
+							defer readCloser.Close()
+						})
+					})
 				})
 			})
 
@@ -110,7 +217,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("don't error", func() {
 					_, err := remote.NewImage(
 						repoName,
-						authn.DefaultKeychain,
+						ggcrauthn.DefaultKeychain,
 						remote.FromBaseImage("some-bad-repo-name"),
 					)
 
@@ -124,7 +231,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("don't error", func() {
 					_, err := remote.NewImage(
 						repoName,
-						authn.DefaultKeychain,
+						ggcrauthn.DefaultKeychain,
 						remote.WithPreviousImage("some-bad-repo-name"),
 					)
 
@@ -137,7 +244,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#Label", func() {
 		when("image exists", func() {
 			it.Before(func() {
-				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				baseImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, baseImage.SetLabel("mykey", "myvalue"))
@@ -146,7 +253,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns the label value", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				label, err := img.Label("mykey")
@@ -155,7 +262,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns an empty string for a missing label", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				label, err := img.Label("missing-label")
@@ -166,7 +273,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("image is empty", func() {
 			it("returns an empty label", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				label, err := img.Label("some-label")
@@ -181,14 +288,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			var baseImageName = newTestImageName()
 
 			it.Before(func() {
-				baseImage, err := remote.NewImage(baseImageName, authn.DefaultKeychain)
+				baseImage, err := remote.NewImage(baseImageName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, baseImage.SetEnv("MY_VAR", "my_val"))
 				h.AssertNil(t, baseImage.Save())
 			})
 
 			it("returns the label value", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(baseImageName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(baseImageName))
 				h.AssertNil(t, err)
 
 				val, err := img.Env("MY_VAR")
@@ -197,7 +304,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns an empty string for a missing label", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(baseImageName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(baseImageName))
 				h.AssertNil(t, err)
 
 				val, err := img.Env("MISSING_VAR")
@@ -208,7 +315,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("image is empty", func() {
 			it("returns an empty string", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				val, err := img.Env("SOME_VAR")
@@ -220,7 +327,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 	when("#Name", func() {
 		it("always returns the original name", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 			h.AssertNil(t, err)
 			h.AssertEq(t, img.Name(), repoName)
 		})
@@ -229,7 +336,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#CreatedAt", func() {
 		const reference = "busybox@sha256:f79f7a10302c402c052973e3fa42be0344ae6453245669783a9e16da3d56d5b4"
 		it("returns the containers created at time", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(reference))
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(reference))
 			h.AssertNil(t, err)
 
 			expectedTime := time.Date(2019, 4, 2, 23, 32, 10, 727183061, time.UTC)
@@ -245,7 +352,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("returns a digest reference", func() {
 			img, err := remote.NewImage(
 				repoName+":some-tag",
-				authn.DefaultKeychain,
+				ggcrauthn.DefaultKeychain,
 				remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 			)
 			h.AssertNil(t, err)
@@ -258,7 +365,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it("accurately parses the reference for an image with a sha", func() {
 			img, err := remote.NewImage(
 				repoName+"@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5",
-				authn.DefaultKeychain,
+				ggcrauthn.DefaultKeychain,
 				remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 			)
 			h.AssertNil(t, err)
@@ -272,7 +379,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns the new digest reference", func() {
 				img, err := remote.NewImage(
 					repoName+":some-tag",
-					authn.DefaultKeychain,
+					ggcrauthn.DefaultKeychain,
 					remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
 				)
 				h.AssertNil(t, err)
@@ -284,8 +391,17 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				id, err := img.Identifier()
 				h.AssertNil(t, err)
 
-				label := remoteLabel(t, dockerClient, id.String(), "new")
-				h.AssertEq(t, "label", label)
+				testImg, err := remote.NewImage(
+					"test",
+					ggcrauthn.DefaultKeychain,
+					remote.FromBaseImage(id.String()),
+				)
+				h.AssertNil(t, err)
+
+				remoteLabel, err := testImg.Label("new")
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, remoteLabel, "label")
 			})
 		})
 	})
@@ -293,7 +409,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#SetLabel", func() {
 		when("image exists", func() {
 			it("sets label on img object", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, img.SetLabel("mykey", "new-val"))
@@ -303,23 +419,31 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("saves label", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, img.SetLabel("mykey", "new-val"))
 
 				h.AssertNil(t, img.Save())
 
-				// After Pull
-				label := remoteLabel(t, dockerClient, repoName, "mykey")
-				h.AssertEq(t, "new-val", label)
+				testImg, err := remote.NewImage(
+					"test",
+					ggcrauthn.DefaultKeychain,
+					remote.FromBaseImage(repoName),
+				)
+				h.AssertNil(t, err)
+
+				remoteLabel, err := testImg.Label("mykey")
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, remoteLabel, "new-val")
 			})
 		})
 	})
 
 	when("#SetEnv", func() {
 		it("sets the environment", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetEnv("ENV_KEY", "ENV_VAL")
@@ -327,19 +451,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			h.AssertNil(t, h.PullImage(dockerClient, repoName))
-			defer h.DockerRmi(dockerClient, repoName)
-
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-			h.AssertNil(t, err)
-
-			h.AssertContains(t, inspect.Config.Env, "ENV_KEY=ENV_VAL")
+			configFile := h.FetchManifestImageConfigFile(t, repoName)
+			h.AssertContains(t, configFile.Config.Env, "ENV_KEY=ENV_VAL")
 		})
 	})
 
 	when("#SetWorkingDir", func() {
 		it("sets the environment", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetWorkingDir("/some/work/dir")
@@ -347,19 +466,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			h.AssertNil(t, h.PullImage(dockerClient, repoName))
-			defer h.DockerRmi(dockerClient, repoName)
-
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-			h.AssertNil(t, err)
-
-			h.AssertEq(t, inspect.Config.WorkingDir, "/some/work/dir")
+			configFile := h.FetchManifestImageConfigFile(t, repoName)
+			h.AssertEq(t, configFile.Config.WorkingDir, "/some/work/dir")
 		})
 	})
 
 	when("#SetEntrypoint", func() {
 		it("sets the entrypoint", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetEntrypoint("some", "entrypoint")
@@ -367,19 +481,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			h.AssertNil(t, h.PullImage(dockerClient, repoName))
-			defer h.DockerRmi(dockerClient, repoName)
-
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-			h.AssertNil(t, err)
-
-			h.AssertEq(t, []string(inspect.Config.Entrypoint), []string{"some", "entrypoint"})
+			configFile := h.FetchManifestImageConfigFile(t, repoName)
+			h.AssertEq(t, configFile.Config.Entrypoint, []string{"some", "entrypoint"})
 		})
 	})
 
 	when("#SetCmd", func() {
 		it("sets the cmd", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 			h.AssertNil(t, err)
 
 			err = img.SetCmd("some", "cmd")
@@ -387,13 +496,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			h.AssertNil(t, h.PullImage(dockerClient, repoName))
-			defer h.DockerRmi(dockerClient, repoName)
-
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-			h.AssertNil(t, err)
-
-			h.AssertEq(t, []string(inspect.Config.Cmd), []string{"some", "cmd"})
+			configFile := h.FetchManifestImageConfigFile(t, repoName)
+			h.AssertEq(t, configFile.Config.Cmd, []string{"some", "cmd"})
 		})
 	})
 
@@ -404,15 +508,15 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it.Before(func() {
 				// new base
 				newBase = "localhost:" + registryPort + "/pack-newbase-test-" + h.RandString(10)
-				newBaseLayer1Path, err := h.CreateSingleFileTar("/base.txt", "new-base")
+				newBaseLayer1Path, err := h.CreateSingleFileLayerTar("/base.txt", "new-base")
 				h.AssertNil(t, err)
 				defer os.Remove(newBaseLayer1Path)
 
-				newBaseLayer2Path, err := h.CreateSingleFileTar("/otherfile.txt", "text-new-base")
+				newBaseLayer2Path, err := h.CreateSingleFileLayerTar("/otherfile.txt", "text-new-base")
 				h.AssertNil(t, err)
 				defer os.Remove(newBaseLayer2Path)
 
-				newBaseImage, err := remote.NewImage(newBase, authn.DefaultKeychain)
+				newBaseImage, err := remote.NewImage(newBase, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = newBaseImage.AddLayer(newBaseLayer1Path)
@@ -423,19 +527,19 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, newBaseImage.Save())
 
-				newBaseLayers = manifestLayers(t, newBase)
+				newBaseLayers = h.FetchManifestLayers(t, newBase)
 
 				// old base image
 				oldBase = "localhost:" + registryPort + "/pack-oldbase-test-" + h.RandString(10)
-				oldBaseLayer1Path, err := h.CreateSingleFileTar("/base.txt", "old-base")
+				oldBaseLayer1Path, err := h.CreateSingleFileLayerTar("/base.txt", "old-base")
 				h.AssertNil(t, err)
 				defer os.Remove(oldBaseLayer1Path)
 
-				oldBaseLayer2Path, err := h.CreateSingleFileTar("/otherfile.txt", "text-old-base")
+				oldBaseLayer2Path, err := h.CreateSingleFileLayerTar("/otherfile.txt", "text-old-base")
 				h.AssertNil(t, err)
 				defer os.Remove(oldBaseLayer2Path)
 
-				oldBaseImage, err := remote.NewImage(oldBase, authn.DefaultKeychain)
+				oldBaseImage, err := remote.NewImage(oldBase, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = oldBaseImage.AddLayer(oldBaseLayer1Path)
@@ -449,18 +553,18 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, oldBaseImage.Save())
 
-				oldBaseLayers = manifestLayers(t, oldBase)
+				oldBaseLayers = h.FetchManifestLayers(t, oldBase)
 
 				// original image
-				origLayer1Path, err := h.CreateSingleFileTar("/bmyimage.txt", "text-from-image-1")
+				origLayer1Path, err := h.CreateSingleFileLayerTar("/bmyimage.txt", "text-from-image-1")
 				h.AssertNil(t, err)
 				defer os.Remove(origLayer1Path)
 
-				origLayer2Path, err := h.CreateSingleFileTar("/myimage2.txt", "text-from-image-2")
+				origLayer2Path, err := h.CreateSingleFileLayerTar("/myimage2.txt", "text-from-image-2")
 				h.AssertNil(t, err)
 				defer os.Remove(origLayer2Path)
 
-				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(oldBase))
+				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(oldBase))
 				h.AssertNil(t, err)
 
 				err = origImage.AddLayer(origLayer1Path)
@@ -471,20 +575,21 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, origImage.Save())
 
-				repoTopLayers = manifestLayers(t, repoName)[len(oldBaseLayers):]
+				repoLayers := h.FetchManifestLayers(t, repoName)
+				repoTopLayers = repoLayers[len(oldBaseLayers):]
 			})
 
 			it("switches the base", func() {
 				// Before
 				h.AssertEq(t,
-					manifestLayers(t, repoName),
+					h.FetchManifestLayers(t, repoName),
 					append(oldBaseLayers, repoTopLayers...),
 				)
 
 				// Run rebase
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
-				newBaseImg, err := remote.NewImage(newBase, authn.DefaultKeychain, remote.FromBaseImage(newBase))
+				newBaseImg, err := remote.NewImage(newBase, ggcrauthn.DefaultKeychain, remote.FromBaseImage(newBase))
 				h.AssertNil(t, err)
 				err = img.Rebase(oldTopLayerDiffID, newBaseImg)
 				h.AssertNil(t, err)
@@ -492,7 +597,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				// After
 				h.AssertEq(t,
-					manifestLayers(t, repoName),
+					h.FetchManifestLayers(t, repoName),
 					append(newBaseLayers, repoTopLayers...),
 				)
 			})
@@ -502,18 +607,18 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#TopLayer", func() {
 		when("image exists", func() {
 			it("returns the digest for the top layer (useful for rebasing)", func() {
-				baseLayerPath, err := h.CreateSingleFileTar("/old-base.txt", "old-base")
+				baseLayerPath, err := h.CreateSingleFileLayerTar("/old-base.txt", "old-base")
 				h.AssertNil(t, err)
 				defer os.Remove(baseLayerPath)
 
-				topLayerPath, err := h.CreateSingleFileTar("/top-layer.txt", "top-layer")
+				topLayerPath, err := h.CreateSingleFileLayerTar("/top-layer.txt", "top-layer")
 				h.AssertNil(t, err)
 				defer os.Remove(topLayerPath)
 
 				expectedTopLayerDiffID, err := h.FileDiffID(topLayerPath)
 				h.AssertNil(t, err)
 
-				existingImage, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				existingImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				err = existingImage.AddLayer(baseLayerPath)
@@ -524,7 +629,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, existingImage.Save())
 
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
 				actualTopLayerDiffID, err := img.TopLayer()
@@ -536,7 +641,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("the image has no layers", func() {
 			it("returns an error", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				_, err = img.TopLayer()
@@ -549,15 +654,16 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			existingImage, err := remote.NewImage(
 				repoName,
-				authn.DefaultKeychain,
+				ggcrauthn.DefaultKeychain,
+				remote.WithDefaultPlatform(ggcrv1.Platform{OS: daemonOS}), //must match for CreateContainer
 			)
 			h.AssertNil(t, err)
 
-			oldLayerPath, err := h.CreateSingleFileTar("/old-layer.txt", "old-layer")
+			baseLayerPath, err := h.CreateSingleFileLayerTar("/base-layer.txt", "base-layer", h.BaseLayerOption, h.LayerOption(daemonOS))
 			h.AssertNil(t, err)
-			defer os.Remove(oldLayerPath)
+			defer os.Remove(baseLayerPath)
 
-			h.AssertNil(t, existingImage.AddLayer(oldLayerPath))
+			h.AssertNil(t, existingImage.AddLayer(baseLayerPath))
 
 			h.AssertNil(t, existingImage.Save())
 		})
@@ -567,11 +673,15 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("appends a layer", func() {
-			newLayerPath, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
+			newLayerPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", h.LayerOption(daemonOS))
 			h.AssertNil(t, err)
 			defer os.Remove(newLayerPath)
 
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+			img, err := remote.NewImage(
+				repoName,
+				ggcrauthn.DefaultKeychain,
+				remote.FromBaseImage(repoName),
+			)
 			h.AssertNil(t, err)
 
 			err = img.AddLayer(newLayerPath)
@@ -582,9 +692,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			// After Pull
 			h.AssertNil(t, h.PullImage(dockerClient, repoName))
 
-			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "old-layer.txt")
+			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "base-layer.txt")
 			h.AssertNil(t, err)
-			h.AssertEq(t, output, "old-layer")
+			h.AssertEq(t, output, "base-layer")
 
 			output, err = h.CopySingleFileFromImage(dockerClient, repoName, "new-layer.txt")
 			h.AssertNil(t, err)
@@ -596,15 +706,16 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			existingImage, err := remote.NewImage(
 				repoName,
-				authn.DefaultKeychain,
+				ggcrauthn.DefaultKeychain,
+				remote.WithDefaultPlatform(ggcrv1.Platform{OS: daemonOS}), //must match for CreateContainer
 			)
 			h.AssertNil(t, err)
 
-			oldLayerPath, err := h.CreateSingleFileTar("/old-layer.txt", "old-layer")
+			baseLayerPath, err := h.CreateSingleFileLayerTar("/base-layer.txt", "base-layer", h.BaseLayerOption, h.LayerOption(daemonOS))
 			h.AssertNil(t, err)
-			defer os.Remove(oldLayerPath)
+			defer os.Remove(baseLayerPath)
 
-			h.AssertNil(t, existingImage.AddLayer(oldLayerPath))
+			h.AssertNil(t, existingImage.AddLayer(baseLayerPath))
 
 			h.AssertNil(t, existingImage.Save())
 		})
@@ -614,10 +725,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("appends a layer", func() {
-			img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+			img, err := remote.NewImage(
+				repoName,
+				ggcrauthn.DefaultKeychain,
+				remote.FromBaseImage(repoName),
+			)
 			h.AssertNil(t, err)
 
-			newLayerPath, err := h.CreateSingleFileTar("/new-layer.txt", "new-layer")
+			newLayerPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", h.LayerOption(daemonOS))
 			h.AssertNil(t, err)
 			defer os.Remove(newLayerPath)
 
@@ -632,9 +747,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			// After Pull
 			h.AssertNil(t, h.PullImage(dockerClient, repoName))
 
-			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "old-layer.txt")
+			output, err := h.CopySingleFileFromImage(dockerClient, repoName, "base-layer.txt")
 			h.AssertNil(t, err)
-			h.AssertEq(t, output, "old-layer")
+			h.AssertEq(t, output, "base-layer")
 
 			output, err = h.CopySingleFileFromImage(dockerClient, repoName, "new-layer.txt")
 			h.AssertNil(t, err)
@@ -653,15 +768,15 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				prevImageName = "localhost:" + registryPort + "/pack-image-test-" + h.RandString(10)
 				prevImage, err := remote.NewImage(
 					prevImageName,
-					authn.DefaultKeychain,
+					ggcrauthn.DefaultKeychain,
 				)
 				h.AssertNil(t, err)
 
-				layer1Path, err := h.CreateSingleFileTar("/layer-1.txt", "old-layer-1")
+				layer1Path, err := h.CreateSingleFileLayerTar("/layer-1.txt", "old-layer-1", h.BaseLayerOption, h.LayerOption(daemonOS))
 				h.AssertNil(t, err)
 				defer os.Remove(layer1Path)
 
-				layer2Path, err := h.CreateSingleFileTar("/layer-2.txt", "old-layer-2")
+				layer2Path, err := h.CreateSingleFileLayerTar("/layer-2.txt", "old-layer-2", h.LayerOption(daemonOS))
 				h.AssertNil(t, err)
 				defer os.Remove(layer2Path)
 
@@ -677,10 +792,17 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("reuses a layer", func() {
 				img, err := remote.NewImage(
 					repoName,
-					authn.DefaultKeychain,
+					ggcrauthn.DefaultKeychain,
 					remote.WithPreviousImage(prevImageName),
+					remote.WithDefaultPlatform(ggcrv1.Platform{OS: daemonOS}), //must match for CreateContainer
 				)
 				h.AssertNil(t, err)
+
+				newBaseLayerPath, err := h.CreateSingleFileLayerTar("/new-base.txt", "base-content", h.BaseLayerOption, h.LayerOption(daemonOS))
+				h.AssertNil(t, err)
+				defer os.Remove(newBaseLayerPath)
+
+				h.AssertNil(t, img.AddLayer(newBaseLayerPath))
 
 				err = img.ReuseLayer(layer2SHA)
 				h.AssertNil(t, err)
@@ -701,7 +823,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns error on nonexistent layer", func() {
 				img, err := remote.NewImage(
 					repoName,
-					authn.DefaultKeychain,
+					ggcrauthn.DefaultKeychain,
 					remote.WithPreviousImage(prevImageName),
 				)
 				h.AssertNil(t, err)
@@ -720,17 +842,17 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			var tarPath string
 
 			it.Before(func() {
-				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				existingImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
-				h.AssertNil(t, baseImage.SetLabel("mykey", "oldValue"))
-				h.AssertNil(t, baseImage.Save())
+				h.AssertNil(t, existingImage.SetLabel("mykey", "oldValue"))
+				h.AssertNil(t, existingImage.Save())
 
 				tarFile, err := ioutil.TempFile("", "add-layer-test")
 				h.AssertNil(t, err)
 				defer tarFile.Close()
 
-				tarPath, err = h.CreateSingleFileTar("/new-layer.txt", "new-layer")
+				tarPath, err = h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer")
 				h.AssertNil(t, err)
 			})
 
@@ -739,7 +861,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("can be pulled by digest", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				err = img.SetLabel("mykey", "newValue")
@@ -750,33 +872,36 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				identifier, err := img.Identifier()
 				h.AssertNil(t, err)
 
-				// After Pull
-				label := remoteLabel(t, dockerClient, identifier.String(), "mykey")
-				h.AssertEq(t, "newValue", label)
+				testImg, err := remote.NewImage(
+					"test",
+					ggcrauthn.DefaultKeychain,
+					remote.FromBaseImage(identifier.String()),
+				)
+				h.AssertNil(t, err)
+
+				remoteLabel, err := testImg.Label("mykey")
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, remoteLabel, "newValue")
 			})
 
 			it("zeroes all times and client specific fields", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, img.AddLayer(tarPath))
 
 				h.AssertNil(t, img.Save())
 
-				h.AssertNil(t, h.PullImage(dockerClient, repoName))
-				defer h.DockerRmi(dockerClient, repoName)
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
-				h.AssertNil(t, err)
+				configFile := h.FetchManifestImageConfigFile(t, repoName)
 
-				h.AssertEq(t, inspect.Created, imgutil.NormalizedDateTime.Format(time.RFC3339))
-				h.AssertEq(t, inspect.Container, "")
-				h.AssertEq(t, inspect.DockerVersion, "")
+				h.AssertEq(t, configFile.Created.Time, imgutil.NormalizedDateTime)
+				h.AssertEq(t, configFile.Container, "")
+				h.AssertEq(t, configFile.DockerVersion, "")
 
-				history, err := dockerClient.ImageHistory(context.TODO(), repoName)
-				h.AssertNil(t, err)
-				h.AssertEq(t, len(history), len(inspect.RootFS.Layers))
-				for _, item := range history {
-					h.AssertEq(t, item.Created, imgutil.NormalizedDateTime.Unix())
+				h.AssertEq(t, len(configFile.History), len(configFile.RootFS.DiffIDs))
+				for _, item := range configFile.History {
+					h.AssertEq(t, item.Created.Unix(), imgutil.NormalizedDateTime.Unix())
 				}
 			})
 		})
@@ -792,17 +917,15 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				successfulRepoNames = append([]string{repoName}, additionalRepoNames...)
 			)
 
-			it.After(func() {
-				h.AssertNil(t, h.DockerRmi(dockerClient, successfulRepoNames...))
-			})
-
 			it("saves to multiple names", func() {
-				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertNil(t, image.Save(additionalRepoNames...))
 				for _, n := range successfulRepoNames {
-					h.AssertNil(t, h.PullImage(dockerClient, n))
+					testImg, err := remote.NewImage(n, ggcrauthn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, testImg.Found(), true)
 				}
 			})
 
@@ -810,7 +933,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				it("returns results with errors for those that failed", func() {
 					failingName := newTestImageName() + ":🧨"
 
-					image, err := remote.NewImage(repoName, authn.DefaultKeychain)
+					image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 					h.AssertNil(t, err)
 
 					err = image.Save(append([]string{failingName}, additionalRepoNames...)...)
@@ -824,7 +947,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertError(t, saveErr.Errors[0].Cause, "could not parse reference")
 
 					for _, n := range successfulRepoNames {
-						h.AssertNil(t, h.PullImage(dockerClient, n))
+						testImg, err := remote.NewImage(n, ggcrauthn.DefaultKeychain)
+						h.AssertNil(t, err)
+						h.AssertEq(t, testImg.Found(), true)
 					}
 				})
 			})
@@ -834,11 +959,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	when("#Found", func() {
 		when("it exists", func() {
 			it("returns true, nil", func() {
-				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, origImage.Save())
 
-				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, image.Found(), true)
@@ -847,7 +972,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("it does not exist", func() {
 			it("returns false, nil", func() {
-				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				image, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, image.Found(), false)
@@ -859,14 +984,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		when("it exists", func() {
 			var img imgutil.Image
 			it("returns nil and is deleted", func() {
-				origImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				origImage, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertNil(t, origImage.SetLabel("some-label", "some-val"))
 				h.AssertNil(t, origImage.Save())
 
 				img, err = remote.NewImage(
 					repoName,
-					authn.DefaultKeychain,
+					ggcrauthn.DefaultKeychain,
 					remote.FromBaseImage(repoName),
 				)
 
@@ -881,7 +1006,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 		when("it does not exists", func() {
 			it("returns an error", func() {
-				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				img, err := remote.NewImage(repoName, ggcrauthn.DefaultKeychain)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, img.Found(), false)
@@ -889,49 +1014,4 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-}
-
-func manifestLayers(t *testing.T, repoName string) []string {
-	t.Helper()
-
-	arr := strings.SplitN(repoName, "/", 2)
-	if len(arr) != 2 {
-		t.Fatalf("expected repoName to have 1 slash (remote test registry): '%s'", repoName)
-	}
-
-	url := "http://" + arr[0] + "/v2/" + arr[1] + "/manifests/latest"
-	req, err := http.NewRequest("GET", url, nil)
-	h.AssertNil(t, err)
-	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
-	resp, err := http.DefaultClient.Do(req)
-	h.AssertNil(t, err)
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		t.Fatalf("HTTP Status was bad: %s => %d", url, resp.StatusCode)
-	}
-
-	var manifest struct {
-		Layers []struct {
-			Digest string `json:"digest"`
-		} `json:"layers"`
-	}
-	json.NewDecoder(resp.Body).Decode(&manifest)
-	h.AssertNil(t, err)
-
-	outSlice := make([]string, 0, len(manifest.Layers))
-	for _, layer := range manifest.Layers {
-		outSlice = append(outSlice, layer.Digest)
-	}
-
-	return outSlice
-}
-
-func remoteLabel(t *testing.T, dockerCli client.CommonAPIClient, repoName, label string) string {
-	t.Helper()
-
-	h.AssertNil(t, h.PullImage(dockerCli, repoName))
-	defer func() { h.AssertNil(t, h.DockerRmi(dockerCli, repoName)) }()
-	inspect, _, err := dockerCli.ImageInspectWithRaw(context.TODO(), repoName)
-	h.AssertNil(t, err)
-	return inspect.Config.Labels[label]
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -77,6 +77,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				h.AssertEq(t, os, "linux")
 
+				osVersion, err := img.OSVersion()
+				h.AssertNil(t, err)
+				h.AssertEq(t, osVersion, "")
+
 				arch, err := img.Architecture()
 				h.AssertNil(t, err)
 				h.AssertEq(t, arch, "amd64")
@@ -99,6 +103,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					os, err := img.OS()
 					h.AssertNil(t, err)
 					h.AssertEq(t, os, "linux")
+
+					osVersion, err := img.OSVersion()
+					h.AssertNil(t, err)
+					h.AssertEq(t, osVersion, "")
 
 					arch, err := img.Architecture()
 					h.AssertNil(t, err)
@@ -124,6 +132,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					h.AssertEq(t, os, "windows")
 
+					osVersion, err := img.OSVersion()
+					h.AssertNil(t, err)
+					h.AssertEq(t, osVersion, "10.0.17763.1040")
+
 					arch, err := img.Architecture()
 					h.AssertNil(t, err)
 					h.AssertEq(t, arch, "amd64")
@@ -148,6 +160,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						os, err := img.OS()
 						h.AssertNil(t, err)
 						h.AssertEq(t, os, "linux")
+
+						osVersion, err := img.OSVersion()
+						h.AssertNil(t, err)
+						h.AssertEq(t, osVersion, "")
 
 						arch, err := img.Architecture()
 						h.AssertNil(t, err)

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -45,6 +45,7 @@ func (registry *DockerRegistry) Start(t *testing.T) {
 		PortBindings: nat.PortMap{
 			"5000/tcp": []nat.PortBinding{{}},
 		},
+		Isolation: fastestIsolation(DockerCli(t)),
 	}, nil, registry.Name)
 	AssertNil(t, err)
 	err = DockerCli(t).ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -45,7 +45,6 @@ func (registry *DockerRegistry) Start(t *testing.T) {
 		PortBindings: nat.PortMap{
 			"5000/tcp": []nat.PortBinding{{}},
 		},
-		Isolation: fastestIsolation(DockerCli(t)),
 	}, nil, registry.Name)
 	AssertNil(t, err)
 	err = DockerCli(t).ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -209,6 +209,10 @@ func CreateContainer(dockerCli dockercli.CommonAPIClient, repoName string) (stri
 	return ctr.ID, nil
 }
 
+// pick the fastest container isolation possible:
+// Windows 10 defaults to "hyperv", which is very slow for local development
+// Windows Server Core defaults to "process"
+// Linux defaults to "default"
 func fastestIsolation(dockerCli dockercli.CommonAPIClient) dockercontainer.Isolation {
 	daemonInfo, err := dockerCli.Info(context.Background())
 	if err != nil {
@@ -221,6 +225,7 @@ func fastestIsolation(dockerCli dockercli.CommonAPIClient) dockercontainer.Isola
 	return dockercontainer.IsolationDefault
 }
 
+// Copy file from a Docker container based on the image
 func CopySingleFileFromLocalImage(dockerCli dockercli.CommonAPIClient, repoName, path string) (string, error) {
 	ctrID, err := CreateContainer(dockerCli, repoName)
 	if err != nil {
@@ -230,6 +235,7 @@ func CopySingleFileFromLocalImage(dockerCli dockercli.CommonAPIClient, repoName,
 	return CopySingleFileFromContainer(dockerCli, ctrID, path)
 }
 
+// Copy file by using ggcr to fetch the image and search each layer, in order, for the first match
 func CopySingleFileFromRemoteImage(repoName, expectedPath string) (string, error) {
 	r, err := name.ParseReference(repoName, name.WeakValidation)
 	if err != nil {
@@ -528,6 +534,7 @@ func FileDiffID(path string) (string, error) {
 	return diffID, nil
 }
 
+// Return an image that can be used by a daemon of the same OS to create an container or run a command
 func RunnableBaseImage(os string) string {
 	if os == "windows" {
 		// windows/amd64 image from manifest cached on github actions Windows 2019 workers: https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md#docker-images


### PR DESCRIPTION
The intent is to enable imgutil consumers to create Windows and Linux OCI images. 

For local, a Windows image is automatically created if the daemon is Windows, and the Architecture and OS Version will also match. If it's a Linux daemon, the empty image will be Linux. This can be overridden by a base image if desired but will fail to save if the base image OS, OS Version, or Architecture is incompatible with the daemon.

For remote, new images will still always default to `linux/amd64`. Any compliant registry should be able to save any type of valid image, Windows or Linux. 

Change summary:
- remote: NewImage: Use ggcr's default platform preferences (`linux/amd64`) but this is overridden by any base images from `remote.FromBaseImage` option.
- local: explicitly set image's default platform to match the daemon OS/OSVersion/Arch for empty images since only matching images can be stored on the daemon. Note: non-matching architectures (e.g `arm64`) are potentially allowed on a daemon (e.g. `amd64`).
- tests: add coverage for new behavior scenarios
- tests: all tests should be runnable on Linux or Mac GOOS + Docker with Linux containers OR Windows GOOS (1809 or greater) + Docker with Windows containers
- tests: replace "busybox" with specific image manifest references for either Linux or Windows.
- tests: replace "registry:2" with compatible registry container images for Linux or Windows
- tests: change helpers to generate Windows specific layer requirements: base images need specific proprietary files, upper layers need specific parent directories
- tests: use non-default container process isolation to speed up Windows tests
- github actions: add identical jobs for windows

Signed-off-by: Micah Young <ymicah@vmware.com>
Signed-off-by: Andrew Meyer <meyeran@vmware.com>
