### PR TITLE
Use fastest layer compression

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -337,7 +336,7 @@ func (i *Image) GetLayer(sha string) (io.ReadCloser, error) {
 }
 
 func (i *Image) AddLayer(path string) error {
-	layer, err := tarball.LayerFromFile(path, tarball.WithCompressionLevel(gzip.DefaultCompression))
+	layer, err := tarball.LayerFromFile(path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* ggcr does this by default, we will let ggcr do the right thing
* this should meaningfully improve lifecycle exporter performance when publishing to a registry

Potential drawbacks: docker uses the default compression. After this changes docker pull/push will produce an image w/ the same ID but a different digest 