### PR TITLE
Improve Windows Header defaults

### DIFF
--- a/layer/pax_permissions.go
+++ b/layer/pax_permissions.go
@@ -1,0 +1,12 @@
+package layer
+
+// $sddl = (ConvertFrom-SddlString $sddlValue)
+// $sddlBytes = [byte[]]::New($sddl.RawDescriptor.BinaryLength)
+// $sddl.RawDescriptor.GetBinaryForm($sddlBytes, 0)
+// [Convert]::ToBase64String($sddlBytes)
+
+// owner: BUILTIN/Administrators group: BUILTIN/Administrators ($sddlValue="O:BAG:BA")
+const AdministratratorOwnerAndGroupSID = "AQAAgBQAAAAkAAAAAAAAAAAAAAABAgAAAAAABSAAAAAgAgAAAQIAAAAAAAUgAAAAIAIAAA=="
+
+// owner: BUILTIN/Users group: BUILTIN/Users ($sddlValue="O:BUG:BU")
+const UserOwnerAndGroupSID = "AQAAgBQAAAAkAAAAAAAAAAAAAAABAgAAAAAABSAAAAAhAgAAAQIAAAAAAAUgAAAAIQIAAA=="

--- a/layer/windows_writer.go
+++ b/layer/windows_writer.go
@@ -121,7 +121,7 @@ func (w *WindowsWriter) writeDirHeader(header *tar.Header) error {
 
 func (w *WindowsWriter) validateHeader(header *tar.Header) error {
 	if !path.IsAbs(header.Name) {
-		return fmt.Errorf("invalid header came: must be absolute, posix path: %s", header.Name)
+		return fmt.Errorf("invalid header name: must be absolute, posix path: %s", header.Name)
 	}
 	return nil
 }

--- a/layer/windows_writer.go
+++ b/layer/windows_writer.go
@@ -2,6 +2,7 @@ package layer
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"path"
 	"strings"
@@ -28,6 +29,9 @@ func (w *WindowsWriter) WriteHeader(header *tar.Header) error {
 		return err
 	}
 
+	if err := w.validateHeader(header); err != nil {
+		return err
+	}
 	header.Name = layerFilesPath(header.Name)
 
 	err := w.writeParentPaths(header.Name)
@@ -98,5 +102,12 @@ func (w *WindowsWriter) writeDirHeader(header *tar.Header) error {
 		return err
 	}
 	w.writtenParentPaths[header.Name] = true
+	return nil
+}
+
+func (w *WindowsWriter) validateHeader(header *tar.Header) error {
+	if !path.IsAbs(header.Name) {
+		return fmt.Errorf("invalid header came: must be absolute, posix path: %s", header.Name)
+	}
 	return nil
 }

--- a/layer/windows_writer_test.go
+++ b/layer/windows_writer_test.go
@@ -124,17 +124,17 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 				h.AssertError(t, lw.WriteHeader(&tar.Header{
 					Name:     `c:\windows-path.txt`,
 					Typeflag: tar.TypeReg,
-				}), `invalid header came: must be absolute, posix path: c:\windows-path.txt`)
+				}), `invalid header name: must be absolute, posix path: c:\windows-path.txt`)
 
 				h.AssertError(t, lw.WriteHeader(&tar.Header{
 					Name:     `\lonelyfile`,
 					Typeflag: tar.TypeDir,
-				}), `invalid header came: must be absolute, posix path: \lonelyfile`)
+				}), `invalid header name: must be absolute, posix path: \lonelyfile`)
 
 				h.AssertError(t, lw.WriteHeader(&tar.Header{
 					Name:     "Files/cnb/lifecycle/first-file",
 					Typeflag: tar.TypeDir,
-				}), `invalid header came: must be absolute, posix path: Files/cnb/lifecycle/first-file`)
+				}), `invalid header name: must be absolute, posix path: Files/cnb/lifecycle/first-file`)
 			})
 		})
 


### PR DESCRIPTION
The two commits here attempt to generate more valid Windows headers for layer entries.

The first commit validates that incoming header paths are valid POSIX format and not accidental windows paths. No validation happens in `tar.WriteHeader` and this mostly helps us find incorrect usages of `filepath` in consumers of `imgutil`.

The second commit sets basic default PAX record permissions for entries, based on the incoming header's `Uid` and `Gid`. This is needed for images to run on k8s (ContainerD) containers. ContainerD accepts layers with entries missing PAX records but in the generated containers, those files have no permissions and are inaccessible. However, Docker instead generates default permissions for those same entries and in the containers the files are owned by `USER`. So this implementation roughly attempts to do what Docker does for all entries, albeit based on `Uid` and `Gid` to the extent possible.

They map as follows:
- Both UID and GID are 0 => Set Owner + Primary Group to BUILTIN\Administrators
- Any other values => Set Owner + Primary Group to BUILTIN\Users (default group for any real user on the system)

This is a basic implementaion to start with, but a more fine-grained mapping will likely be preferable, perhaps informed by how Linux NTFS or SMB drivers map permissions.
