### PR TITLE
Add the ability to create registry with authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20200311163244-4b1985e5ea21
 	github.com/pkg/errors v0.9.1
 	github.com/sclevine/spec v1.4.0
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2,6 +2,7 @@ package remote_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -25,9 +26,16 @@ func newTestImageName() string {
 func TestRemote(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	dockerRegistry := h.NewDockerRegistry()
+	dockerConfigDir, err := ioutil.TempDir("", "test.docker.config.dir")
+	h.AssertNil(t, err)
+	defer os.RemoveAll(dockerConfigDir)
+
+	dockerRegistry := h.NewDockerRegistryWithAuth(dockerConfigDir)
 	dockerRegistry.Start(t)
 	defer dockerRegistry.Stop(t)
+
+	os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
+	defer os.Unsetenv("DOCKER_CONFIG")
 
 	registryPort = dockerRegistry.Port
 

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -2,18 +2,28 @@ package testhelpers
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type DockerRegistry struct {
-	Port string
-	Name string
+	Port            string
+	Name            string
+	DockerDirectory string
+	username        string
+	password        string
 }
 
 var registryImageNames = map[string]string{
@@ -22,13 +32,23 @@ var registryImageNames = map[string]string{
 }
 
 func NewDockerRegistry() *DockerRegistry {
-	return &DockerRegistry{}
+	return &DockerRegistry{
+		Name: "test-registry-" + RandString(10),
+	}
+}
+
+func NewDockerRegistryWithAuth(dockerConfigDir string) *DockerRegistry {
+	return &DockerRegistry{
+		Name:            "test-registry-" + RandString(10),
+		username:        RandString(10),
+		password:        RandString(10),
+		DockerDirectory: dockerConfigDir,
+	}
 }
 
 func (registry *DockerRegistry) Start(t *testing.T) {
 	t.Log("run registry")
 	t.Helper()
-	registry.Name = "test-registry-" + RandString(10)
 
 	ctx := context.Background()
 	daemonInfo, err := DockerCli(t).Info(ctx)
@@ -37,9 +57,29 @@ func (registry *DockerRegistry) Start(t *testing.T) {
 	registryImageName := registryImageNames[daemonInfo.OSType]
 	AssertNil(t, PullImage(DockerCli(t), registryImageName))
 
+	var htpasswdTar io.ReadCloser
+	registryEnv := []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"}
+	if registry.username != "" {
+		// Create htpasswdTar and configure registry env
+		tempDir, err := ioutil.TempDir("", "test.registry")
+		AssertNil(t, err)
+		defer os.RemoveAll(tempDir)
+
+		htpasswdTar = generateHtpasswd(t, tempDir, registry.username, registry.password)
+		defer htpasswdTar.Close()
+
+		otherEnvs := []string{
+			"REGISTRY_AUTH=htpasswd",
+			"REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
+			"REGISTRY_AUTH_HTPASSWD_PATH=/registry_test_htpasswd",
+		}
+		registryEnv = append(registryEnv, otherEnvs...)
+	}
+
+	// Create container
 	ctr, err := DockerCli(t).ContainerCreate(ctx, &container.Config{
 		Image: registryImageName,
-		Env:   []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"},
+		Env:   registryEnv,
 	}, &container.HostConfig{
 		AutoRemove: true,
 		PortBindings: nat.PortMap{
@@ -47,15 +87,30 @@ func (registry *DockerRegistry) Start(t *testing.T) {
 		},
 	}, nil, registry.Name)
 	AssertNil(t, err)
-	err = DockerCli(t).ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{})
-	AssertNil(t, err)
 
+	if registry.username != "" {
+		// Copy htpasswdTar to container
+		AssertNil(t, DockerCli(t).CopyToContainer(ctx, ctr.ID, "/", htpasswdTar, types.CopyToContainerOptions{}))
+	}
+
+	// Start container
+	AssertNil(t, DockerCli(t).ContainerStart(ctx, ctr.ID, types.ContainerStartOptions{}))
+
+	// Get port
 	inspect, err := DockerCli(t).ContainerInspect(ctx, ctr.ID)
 	AssertNil(t, err)
 	registry.Port = inspect.NetworkSettings.Ports["5000/tcp"][0].HostPort
 
+	var authHeaders map[string]string
+	if registry.username != "" {
+		// Write Docker config and configure auth headers
+		writeDockerConfig(t, registry.DockerDirectory, registry.Port, registry.encodedAuth())
+		authHeaders = map[string]string{"Authorization": "Basic " + registry.encodedAuth()}
+	}
+
+	// Wait for registry to be ready
 	Eventually(t, func() bool {
-		txt, err := HTTPGetE(fmt.Sprintf("http://localhost:%s/v2/", registry.Port))
+		txt, err := HTTPGetE(fmt.Sprintf("http://localhost:%s/v2/_catalog", registry.Port), authHeaders)
 		return err == nil && txt != ""
 	}, 100*time.Millisecond, 10*time.Second)
 }
@@ -67,4 +122,53 @@ func (registry *DockerRegistry) Stop(t *testing.T) {
 		DockerCli(t).ContainerKill(context.Background(), registry.Name, "SIGKILL")
 		DockerCli(t).ContainerRemove(context.TODO(), registry.Name, types.ContainerRemoveOptions{Force: true})
 	}
+}
+
+func (registry *DockerRegistry) RepoName(name string) string {
+	return "localhost:" + registry.Port + "/" + name
+}
+
+func (registry *DockerRegistry) EncodedLabeledAuth() string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"username":"%s","password":"%s"}`, registry.username, registry.password)))
+}
+
+func (registry *DockerRegistry) encodedAuth() string {
+	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", registry.username, registry.password)))
+}
+
+func generateHtpasswd(t *testing.T, tempDir string, username string, password string) io.ReadCloser {
+	// https://docs.docker.com/registry/deploying/#restricting-access
+	// HTPASSWD format: https://github.com/foomo/htpasswd/blob/e3a90e78da9cff06a83a78861847aa9092cbebdd/hashing.go#L23
+	passwordBytes, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+
+	// Write data to file
+	htpasswdFile, err := os.Create(filepath.Join(tempDir, "registry_test_htpasswd"))
+	AssertNil(t, err)
+	htpasswdFile.Write([]byte(username + ":" + string(passwordBytes)))
+
+	// Write tar file
+	cmd := exec.Command("tar", "cf", "htpasswdTar", "registry_test_htpasswd")
+	cmd.Dir = tempDir
+	AssertNil(t, cmd.Run())
+
+	// Return a reader to tar file
+	reader, err := os.Open(filepath.Join(tempDir, "htpasswdTar"))
+	AssertNil(t, err)
+
+	return reader
+}
+
+func writeDockerConfig(t *testing.T, configDir, port, auth string) {
+	AssertNil(t, ioutil.WriteFile(
+		filepath.Join(configDir, "config.json"),
+		[]byte(fmt.Sprintf(`{
+			  "auths": {
+			    "localhost:%s": {
+			      "auth": "%s"
+			    }
+			  }
+			}
+			`, port, auth)),
+		0666,
+	))
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -218,6 +218,24 @@ func ImageID(t *testing.T, repoName string) string {
 	return inspect.ID
 }
 
+func CreateSingleFileTarReader(path, txt string) io.ReadCloser {
+	pr, pw := io.Pipe()
+
+	go func() {
+		var err error
+		defer func() {
+			pw.CloseWithError(err)
+		}()
+
+		tw := tar.NewWriter(pw)
+		defer tw.Close()
+
+		err = writeTarSingleFileLinux(tw, path, txt) // Use the Linux writer, as this isn't a layer tar.
+	}()
+
+	return pr
+}
+
 func CreateSingleFileLayerTar(layerPath, txt, osType string) (string, error) {
 	tarFile, err := ioutil.TempFile("", "create-single-file-layer-tar-path")
 	if err != nil {


### PR DESCRIPTION
This PR is intended to add functionality to the docker registry in `testhelpers` so that this package can be used in the lifecycle acceptance tests. We need the ability to create a registry with authentication.

I am not sure about all of the `registry.username != ""` in `registry.Start()` - maybe it's better to have a different method or something.

Signed-off-by: Natalie Arellano <narellano@vmware.com>