### PR TITLE
Fix remote rebase losing platform values

### DIFF
--- a/local/local_test.go
+++ b/local/local_test.go
@@ -667,6 +667,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				afterLayer4DiffID := afterInspect.RootFS.Layers[len(afterInspect.RootFS.Layers)-1]
 				h.AssertEq(t, imgLayer2DiffID, afterLayer4DiffID)
+
+				h.AssertEq(t, afterInspect.Os, beforeInspect.Os)
+				h.AssertEq(t, afterInspect.OsVersion, beforeInspect.OsVersion)
+				h.AssertEq(t, afterInspect.Architecture, beforeInspect.Architecture)
 			})
 		})
 	})

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -232,6 +232,26 @@ func (i *Image) Rebase(baseTopLayer string, newBase imgutil.Image) error {
 	if err != nil {
 		return errors.Wrap(err, "rebase")
 	}
+
+	newImageConfig, err := newImage.ConfigFile()
+	if err != nil {
+		return err
+	}
+
+	newBaseRemoteConfig, err := newBaseRemote.image.ConfigFile()
+	if err != nil {
+		return err
+	}
+
+	newImageConfig.Architecture = newBaseRemoteConfig.Architecture
+	newImageConfig.OS = newBaseRemoteConfig.OS
+	newImageConfig.OSVersion = newBaseRemoteConfig.OSVersion
+
+	newImage, err = mutate.ConfigFile(newImage, newImageConfig)
+	if err != nil {
+		return err
+	}
+
 	i.image = newImage
 	return nil
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -533,7 +533,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				repoTopLayers = repoLayers[len(oldBaseLayers):]
 			})
 
-			it.Focus("switches the base", func() {
+			it("switches the base", func() {
 				// Before
 				h.AssertEq(t,
 					h.FetchManifestLayers(t, repoName),
@@ -543,8 +543,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				// Run rebase
 				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
+
 				newBaseImg, err := remote.NewImage(newBase, authn.DefaultKeychain, remote.FromBaseImage(newBase))
 				h.AssertNil(t, err)
+
 				err = img.Rebase(oldTopLayerDiffID, newBaseImg)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
@@ -555,37 +557,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					append(newBaseLayers, repoTopLayers...),
 				)
 
-
-				expectedOS, err := newBaseImg.OS()
-				h.AssertNil(t, err)
-
-				expectedArchitecture, err := newBaseImg.Architecture()
-				h.AssertNil(t, err)
-
-				expectedOSVersion, err := newBaseImg.OSVersion()
-				h.AssertNil(t, err)
-
-				actualOS, err := img.OS()
-				h.AssertNil(t, err)
-
-				actualArchitecture, err := newBaseImg.Architecture()
-				h.AssertNil(t, err)
-
-				actualOSVersion, err := newBaseImg.OSVersion()
-				h.AssertNil(t, err)
-
-				h.AssertEq(t,
-					actualOS,
-					expectedOS,
-				)
-				h.AssertEq(t,
-					actualArchitecture,
-					expectedArchitecture,
-				)
-				h.AssertEq(t,
-					actualOSVersion,
-					expectedOSVersion,
-				)
+				newBaseConfig := h.FetchManifestImageConfigFile(t, newBase)
+				rebasedImgConfig := h.FetchManifestImageConfigFile(t, repoName)
+				h.AssertEq(t, rebasedImgConfig.OS, newBaseConfig.OS)
+				h.AssertEq(t, rebasedImgConfig.OSVersion, newBaseConfig.OSVersion)
+				h.AssertEq(t, rebasedImgConfig.Architecture, newBaseConfig.Architecture)
 			})
 		})
 	})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -533,7 +533,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				repoTopLayers = repoLayers[len(oldBaseLayers):]
 			})
 
-			it("switches the base", func() {
+			it.Focus("switches the base", func() {
 				// Before
 				h.AssertEq(t,
 					h.FetchManifestLayers(t, repoName),
@@ -553,6 +553,38 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t,
 					h.FetchManifestLayers(t, repoName),
 					append(newBaseLayers, repoTopLayers...),
+				)
+
+
+				expectedOS, err := newBaseImg.OS()
+				h.AssertNil(t, err)
+
+				expectedArchitecture, err := newBaseImg.Architecture()
+				h.AssertNil(t, err)
+
+				expectedOSVersion, err := newBaseImg.OSVersion()
+				h.AssertNil(t, err)
+
+				actualOS, err := img.OS()
+				h.AssertNil(t, err)
+
+				actualArchitecture, err := newBaseImg.Architecture()
+				h.AssertNil(t, err)
+
+				actualOSVersion, err := newBaseImg.OSVersion()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t,
+					actualOS,
+					expectedOS,
+				)
+				h.AssertEq(t,
+					actualArchitecture,
+					expectedArchitecture,
+				)
+				h.AssertEq(t,
+					actualOSVersion,
+					expectedOSVersion,
 				)
 			})
 		})


### PR DESCRIPTION
**Problem:**
When `pack rebase` is run on a windows container image, the resulting container image is unable to run on a Windows daemon: the problem is that the image loses its **os.Platform** metadata (for both platforms) during the process. We’ve raised an [issue with google/go-containerregistry](https://github.com/google/go-containerregistry/issues/751), but have implemented a stop-gap within this PR.

**Related:**
* The following PR is intended to address https://github.com/buildpacks/pack/issues/770. For `pack` to have this resolved, it should be rebuilt with code from this PR.
* https://github.com/google/go-containerregistry/issues/751

Signed-off-by: Micah Young <ymicah@vmware.com>
Signed-off-by: Anthony Emengo <aemengo@vmware.com>

@aemengo @micahyoung 
