### PR TITLE
Don't duplicate environment variables

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -235,6 +235,20 @@ func (i *Image) SetLabel(key, val string) error {
 }
 
 func (i *Image) SetEnv(key, val string) error {
+	ignoreCase := i.inspect.Os == "windows"
+	for idx, kv := range i.inspect.Config.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		foundKey := parts[0]
+		searchKey := key
+		if ignoreCase {
+			foundKey = strings.ToUpper(foundKey)
+			searchKey = strings.ToUpper(searchKey)
+		}
+		if foundKey == searchKey {
+			i.inspect.Config.Env[idx] = fmt.Sprintf("%s=%s", key, val)
+			return nil
+		}
+	}
 	i.inspect.Config.Env = append(i.inspect.Config.Env, fmt.Sprintf("%s=%s", key, val))
 	return nil
 }

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -276,9 +276,16 @@ func (i *Image) SetEnv(key, val string) error {
 		return err
 	}
 	config := *configFile.Config.DeepCopy()
+	ignoreCase := configFile.OS == "windows"
 	for idx, e := range config.Env {
 		parts := strings.Split(e, "=")
-		if parts[0] == key {
+		foundKey := parts[0]
+		searchKey := key
+		if ignoreCase {
+			foundKey = strings.ToUpper(foundKey)
+			searchKey = strings.ToUpper(searchKey)
+		}
+		if foundKey == searchKey {
 			config.Env[idx] = fmt.Sprintf("%s=%s", key, val)
 			i.image, err = mutate.Config(i.image, config)
 			if err != nil {


### PR DESCRIPTION
On Windows, ignore case when determining if variable is a duplicate.
Use the casing of the key that was passed in.

Signed-off-by: Yael Harel <yharel@vmware.com>