### PR TITLE
Add #Labels to imgutil.Image

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -20,7 +20,7 @@ import (
 
 func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 	return &Image{
-		labels:        map[string]string{},
+		labels:        nil,
 		env:           map[string]string{},
 		topLayerSha:   topLayerSha,
 		identifier:    identifier,

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -67,6 +67,10 @@ func (i *Image) Label(key string) (string, error) {
 	return i.labels[key], nil
 }
 
+func (i *Image) Labels() (map[string]string, error) {
+	return i.labels, nil
+}
+
 func (i *Image) OS() (string, error) {
 	return i.os, nil
 }

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -101,6 +101,9 @@ func (i *Image) Rebase(baseTopLayer string, newBase imgutil.Image) error {
 }
 
 func (i *Image) SetLabel(k string, v string) error {
+	if i.labels == nil {
+		i.labels = map[string]string{}
+	}
 	i.labels[k] = v
 	return nil
 }

--- a/image.go
+++ b/image.go
@@ -30,6 +30,7 @@ type Image interface {
 	Name() string
 	Rename(name string)
 	Label(string) (string, error)
+	Labels() (map[string]string, error)
 	SetLabel(string, string) error
 	Env(key string) (string, error)
 	SetEnv(string, string) error

--- a/local/local.go
+++ b/local/local.go
@@ -105,6 +105,10 @@ func (i *Image) Label(key string) (string, error) {
 	return labels[key], nil
 }
 
+func (i *Image) Labels() (map[string]string, error) {
+	return i.inspect.Config.Labels, nil
+}
+
 func (i *Image) Env(key string) (string, error) {
 	for _, envVar := range i.inspect.Config.Env {
 		parts := strings.Split(envVar, "=")

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -230,7 +230,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
 			})
 
-			it("returns an empty map", func() {
+			it("returns nil", func() {
 				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -190,7 +190,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Labels", func() {
-		when("image exists", func() {
+		when("image exists with labels", func() {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
@@ -206,7 +206,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
 			})
 
-			it("returns the labels", func() {
+			it("returns all the labels", func() {
 				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
@@ -214,6 +214,40 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				h.AssertEq(t, labels["mykey"], "myvalue")
 				h.AssertEq(t, labels["other"], "data")
+			})
+		})
+
+		when("image exists with no labels", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+				h.AssertNil(t, existingImage.Save())
+			})
+
+			it.After(func() {
+				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+			})
+
+			it("returns an empty map", func() {
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, 0, len(labels))
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns an empty map", func() {
+				img, err := local.NewImage(newTestImageName(), dockerClient)
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, 0, len(labels))
 			})
 		})
 	})

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -189,6 +189,35 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#Labels", func() {
+		when("image exists", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, existingImage.SetLabel("mykey", "myvalue"))
+				h.AssertNil(t, existingImage.SetLabel("other", "data"))
+				h.AssertNil(t, existingImage.Save())
+			})
+
+			it.After(func() {
+				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+			})
+
+			it("returns the labels", func() {
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, labels["mykey"], "myvalue")
+				h.AssertEq(t, labels["other"], "data")
+			})
+		})
+	})
+
 	when("#Label", func() {
 		when("image exists", func() {
 			var repoName = newTestImageName()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -138,6 +138,14 @@ func (i *Image) Label(key string) (string, error) {
 	return labels[key], nil
 }
 
+func (i *Image) Labels() (map[string]string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil {
+		return nil, fmt.Errorf("failed to get config file for image '%s'", i.repoName)
+	}
+	return cfg.Config.Labels, nil
+}
+
 func (i *Image) Env(key string) (string, error) {
 	cfg, err := i.image.ConfigFile()
 	if err != nil || cfg == nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -229,7 +229,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, baseImage.Save())
 			})
 
-			it("returns an empty map", func() {
+			it("returns nil", func() {
 				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
@@ -240,7 +240,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("image NOT exists", func() {
-			it("returns an empty map", func() {
+			it("returns nil", func() {
 				img, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
 				h.AssertNil(t, err)
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -196,6 +196,31 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#Labels", func() {
+		when("image exists", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetLabel("mykey", "myvalue"))
+				h.AssertNil(t, baseImage.SetLabel("other", "data"))
+				h.AssertNil(t, baseImage.Save())
+			})
+
+			it("returns the labels", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, labels["mykey"], "myvalue")
+				h.AssertEq(t, labels["other"], "data")
+			})
+		})
+	})
+
 	when("#Label", func() {
 		when("image exists", func() {
 			it.Before(func() {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -197,7 +197,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("#Labels", func() {
-		when("image exists", func() {
+		when("image exists with labels", func() {
 			var repoName = newTestImageName()
 
 			it.Before(func() {
@@ -209,7 +209,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, baseImage.Save())
 			})
 
-			it("returns the labels", func() {
+			it("returns all the labels", func() {
 				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
 				h.AssertNil(t, err)
 
@@ -217,6 +217,36 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				h.AssertEq(t, labels["mykey"], "myvalue")
 				h.AssertEq(t, labels["other"], "data")
+			})
+		})
+
+		when("image exists with no labels", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+				h.AssertNil(t, baseImage.Save())
+			})
+
+			it("returns an empty map", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, 0, len(labels))
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns an empty map", func() {
+				img, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				labels, err := img.Labels()
+				h.AssertNil(t, err)
+				h.AssertEq(t, 0, len(labels))
 			})
 		})
 	})


### PR DESCRIPTION
We've got [an upcoming feature](https://github.com/buildpacks/lifecycle/issues/390) that requires getting all the lables on an image instead of a specificly named label.