### PR TITLE
Add #RemoveLabel and ensure #Labels returns a copy

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -68,7 +68,11 @@ func (i *Image) Label(key string) (string, error) {
 }
 
 func (i *Image) Labels() (map[string]string, error) {
-	return i.labels, nil
+	copiedLabels := make(map[string]string)
+	for i, l := range i.labels {
+		copiedLabels[i] = l
+	}
+	return copiedLabels, nil
 }
 
 func (i *Image) OS() (string, error) {
@@ -105,6 +109,11 @@ func (i *Image) SetLabel(k string, v string) error {
 		i.labels = map[string]string{}
 	}
 	i.labels[k] = v
+	return nil
+}
+
+func (i *Image) RemoveLabel(key string) error {
+	delete(i.labels, key)
 	return nil
 }
 

--- a/image.go
+++ b/image.go
@@ -32,6 +32,7 @@ type Image interface {
 	Label(string) (string, error)
 	Labels() (map[string]string, error)
 	SetLabel(string, string) error
+	RemoveLabel(string) error
 	Env(key string) (string, error)
 	SetEnv(string, string) error
 	SetEntrypoint(...string) error

--- a/local/local.go
+++ b/local/local.go
@@ -106,7 +106,11 @@ func (i *Image) Label(key string) (string, error) {
 }
 
 func (i *Image) Labels() (map[string]string, error) {
-	return i.inspect.Config.Labels, nil
+	copiedLabels := make(map[string]string)
+	for i, l := range i.inspect.Config.Labels {
+		copiedLabels[i] = l
+	}
+	return copiedLabels, nil
 }
 
 func (i *Image) Env(key string) (string, error) {
@@ -235,6 +239,11 @@ func (i *Image) SetLabel(key, val string) error {
 	}
 
 	i.inspect.Config.Labels[key] = val
+	return nil
+}
+
+func (i *Image) RemoveLabel(key string) error {
+	delete(i.inspect.Config.Labels, key)
 	return nil
 }
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -278,6 +278,17 @@ func (i *Image) SetLabel(key, val string) error {
 	return err
 }
 
+func (i *Image) RemoveLabel(key string) error {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil {
+		return fmt.Errorf("failed to get config file for image '%s'", i.repoName)
+	}
+	config := *cfg.Config.DeepCopy()
+	delete(config.Labels, key)
+	i.image, err = mutate.Config(i.image, config)
+	return err
+}
+
 func (i *Image) SetEnv(key, val string) error {
 	configFile, err := i.image.ConfigFile()
 	if err != nil {


### PR DESCRIPTION
The remote/local #Labels is now returning a copy so the behavior is the same.
Added #RemoveLabel to mutate the map/remote config so consumers can remove labels.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>