### PR TITLE
Adds setters for OS/OSVersion/Architecture

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -80,7 +80,7 @@ func (i *Image) OS() (string, error) {
 }
 
 func (i *Image) OSVersion() (string, error) {
-	return i.os, nil
+	return i.osVersion, nil
 }
 
 func (i *Image) Architecture() (string, error) {
@@ -119,6 +119,21 @@ func (i *Image) RemoveLabel(key string) error {
 
 func (i *Image) SetEnv(k string, v string) error {
 	i.env[k] = v
+	return nil
+}
+
+func (i *Image) SetOS(o string) error {
+	i.os = o
+	return nil
+}
+
+func (i *Image) SetOSVersion(v string) error {
+	i.osVersion = v
+	return nil
+}
+
+func (i *Image) SetArchitecture(a string) error {
+	i.architecture = a
 	return nil
 }
 
@@ -266,12 +281,6 @@ func (i *Image) Found() bool {
 
 func (i *Image) SetIdentifier(identifier imgutil.Identifier) {
 	i.identifier = identifier
-}
-
-func (i *Image) SetPlatform(os, osVersion, architecture string) {
-	i.os = os
-	i.osVersion = osVersion
-	i.architecture = architecture
 }
 
 func (i *Image) Cleanup() error {

--- a/image.go
+++ b/image.go
@@ -38,6 +38,9 @@ type Image interface {
 	SetEntrypoint(...string) error
 	SetWorkingDir(string) error
 	SetCmd(...string) error
+	SetOS(string) error
+	SetOSVersion(string) error
+	SetArchitecture(string) error
 	Rebase(string, Image) error
 	AddLayer(path string) error
 	AddLayerWithDiffID(path, diffID string) error

--- a/local/local.go
+++ b/local/local.go
@@ -242,6 +242,21 @@ func (i *Image) SetLabel(key, val string) error {
 	return nil
 }
 
+func (i *Image) SetOS(osVal string) error {
+	i.inspect.Os = osVal
+	return nil
+}
+
+func (i *Image) SetOSVersion(osVersion string) error {
+	i.inspect.OsVersion = osVersion
+	return nil
+}
+
+func (i *Image) SetArchitecture(architecture string) error {
+	i.inspect.Architecture = architecture
+	return nil
+}
+
 func (i *Image) RemoveLabel(key string) error {
 	delete(i.inspect.Config.Labels, key)
 	return nil

--- a/local/local.go
+++ b/local/local.go
@@ -243,7 +243,9 @@ func (i *Image) SetLabel(key, val string) error {
 }
 
 func (i *Image) SetOS(osVal string) error {
-	i.inspect.Os = osVal
+	if osVal != i.inspect.Os {
+		return fmt.Errorf(`invalid os: must match the daemon: "%s"`, i.inspect.Os)
+	}
 	return nil
 }
 

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -706,23 +706,21 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("#SetOS #SetOSVersion #SetArchitecture", func() {
+	when("#SetOS", func() {
 		var repoName = newTestImageName()
 
 		it.After(func() {
 			h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
 		})
 
-		it("sets the os/arch", func() {
+		it("allows noop sets for values that match the daemon", func() {
 			img, err := local.NewImage(repoName, dockerClient)
 			h.AssertNil(t, err)
 
-			//os has to match daemon
+			err = img.SetOS("fakeos")
+			h.AssertError(t, err, "invalid os: must match the daemon")
+
 			err = img.SetOS(daemonOS)
-			h.AssertNil(t, err)
-			err = img.SetOSVersion("1.2.3.4")
-			h.AssertNil(t, err)
-			err = img.SetArchitecture("arm64")
 			h.AssertNil(t, err)
 
 			h.AssertNil(t, img.Save())
@@ -731,6 +729,31 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, inspect.Os, daemonOS)
+		})
+	})
+
+	when("#SetOSVersion #SetArchitecture", func() {
+		var repoName = newTestImageName()
+
+		it.After(func() {
+			h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+		})
+
+		it("sets the os.version/arch", func() {
+			img, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			err = img.SetOSVersion("1.2.3.4")
+			h.AssertNil(t, err)
+
+			err = img.SetArchitecture("arm64")
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, img.Save())
+
+			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
 			h.AssertEq(t, inspect.OsVersion, "1.2.3.4")
 			h.AssertEq(t, inspect.Architecture, "arm64")
 		})

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -706,6 +706,36 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#SetOS #SetOSVersion #SetArchitecture", func() {
+		var repoName = newTestImageName()
+
+		it.After(func() {
+			h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+		})
+
+		it("sets the os/arch", func() {
+			img, err := local.NewImage(repoName, dockerClient)
+			h.AssertNil(t, err)
+
+			//os has to match daemon
+			err = img.SetOS(daemonOS)
+			h.AssertNil(t, err)
+			err = img.SetOSVersion("1.2.3.4")
+			h.AssertNil(t, err)
+			err = img.SetArchitecture("arm64")
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, img.Save())
+
+			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			h.AssertNil(t, err)
+
+			h.AssertEq(t, inspect.Os, daemonOS)
+			h.AssertEq(t, inspect.OsVersion, "1.2.3.4")
+			h.AssertEq(t, inspect.Architecture, "arm64")
+		})
+	})
+
 	when("#Rebase", func() {
 		when("image exists", func() {
 			var (

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -351,6 +351,36 @@ func (i *Image) SetCmd(cmd ...string) error {
 	return err
 }
 
+func (i *Image) SetOS(osVal string) error {
+	configFile, err := i.image.ConfigFile()
+	if err != nil {
+		return err
+	}
+	configFile.OS = osVal
+	i.image, err = mutate.ConfigFile(i.image, configFile)
+	return err
+}
+
+func (i *Image) SetOSVersion(osVersion string) error {
+	configFile, err := i.image.ConfigFile()
+	if err != nil {
+		return err
+	}
+	configFile.OSVersion = osVersion
+	i.image, err = mutate.ConfigFile(i.image, configFile)
+	return err
+}
+
+func (i *Image) SetArchitecture(architecture string) error {
+	configFile, err := i.image.ConfigFile()
+	if err != nil {
+		return err
+	}
+	configFile.Architecture = architecture
+	i.image, err = mutate.ConfigFile(i.image, configFile)
+	return err
+}
+
 func (i *Image) TopLayer() (string, error) {
 	all, err := i.image.Layers()
 	if err != nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -612,6 +612,27 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#SetOS #SetOSVersion #SetArchitecture", func() {
+		it("sets the os/arch", func() {
+			img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+			h.AssertNil(t, err)
+
+			err = img.SetOS("foobaros")
+			h.AssertNil(t, err)
+			err = img.SetOSVersion("1.2.3.4")
+			h.AssertNil(t, err)
+			err = img.SetArchitecture("arm64")
+			h.AssertNil(t, err)
+
+			h.AssertNil(t, img.Save())
+
+			configFile := h.FetchManifestImageConfigFile(t, repoName)
+			h.AssertEq(t, configFile.OS, "foobaros")
+			h.AssertEq(t, configFile.OSVersion, "1.2.3.4")
+			h.AssertEq(t, configFile.Architecture, "arm64")
+		})
+	})
+
 	when("#Rebase", func() {
 		when("image exists", func() {
 			var oldBase, newBase, oldTopLayerDiffID string


### PR DESCRIPTION
Required to create valid, empty images without `FromBaseImage`

This will be important for Windows buildpackages in pack (currently draft PR: https://github.com/buildpacks/pack/pull/840), which will not use `FromBaseImage`