### PR TITLE
add Entrypoint method to remote and local images

### DIFF
--- a/image.go
+++ b/image.go
@@ -34,6 +34,7 @@ type Image interface {
 	SetLabel(string, string) error
 	RemoveLabel(string) error
 	Env(key string) (string, error)
+	Entrypoint() ([]string, error)
 	SetEnv(string, string) error
 	SetEntrypoint(...string) error
 	SetWorkingDir(string) error

--- a/local/local.go
+++ b/local/local.go
@@ -120,6 +120,10 @@ func (i *Image) Env(key string) (string, error) {
 	return "", nil
 }
 
+func (i *Image) Entrypoint() ([]string, error) {
+	return i.inspect.Config.Entrypoint, nil
+}
+
 func (i *Image) OS() (string, error) {
 	return i.inspect.Os, nil
 }

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -346,6 +346,60 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#Entrypoint", func() {
+		when("image exists", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, existingImage.SetEntrypoint("entrypoint1", "entrypoint2"))
+				h.AssertNil(t, existingImage.Save())
+			})
+
+			it.After(func() {
+				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+			})
+
+			it("returns the entrypoint value", func() {
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, val, []string{"entrypoint1", "entrypoint2"})
+			})
+
+			it("returns nil slice for a missing entrypoint", func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+				h.AssertNil(t, existingImage.Save())
+
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+				var expected []string
+				h.AssertEq(t, val, expected)
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns nil slice", func() {
+				img, err := local.NewImage(newTestImageName(), dockerClient)
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+				var expected []string
+				h.AssertEq(t, val, expected)
+			})
+		})
+	})
+
 	when("#Name", func() {
 		it("always returns the original name", func() {
 			var repoName = newTestImageName()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -160,6 +160,14 @@ func (i *Image) Env(key string) (string, error) {
 	return "", nil
 }
 
+func (i *Image) Entrypoint() ([]string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil || cfg == nil {
+		return nil, fmt.Errorf("failed to get config file for image '%s'", i.repoName)
+	}
+	return cfg.Config.Entrypoint, nil
+}
+
 func (i *Image) OS() (string, error) {
 	cfg, err := i.image.ConfigFile()
 	if err != nil || cfg == nil || cfg.OS == "" {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -196,6 +196,55 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#Entrypoint", func() {
+		when("image exists with entrypoint", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetEntrypoint("entrypoint1", "entrypoint2"))
+				h.AssertNil(t, baseImage.Save())
+			})
+
+			it("returns the entrypoint value", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+				h.AssertEq(t, val, []string{"entrypoint1", "entrypoint2"})
+			})
+
+			it("returns nil slice for a missing entrypoint", func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+				h.AssertNil(t, baseImage.Save())
+
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+				var expected []string
+				h.AssertEq(t, val, expected)
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns nil slice", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				val, err := img.Entrypoint()
+				h.AssertNil(t, err)
+				var expected []string
+				h.AssertEq(t, val, expected)
+			})
+		})
+	})
+
 	when("#Labels", func() {
 		when("image exists with labels", func() {
 			var repoName = newTestImageName()


### PR DESCRIPTION
This would be helpful for `pack` when determining the entrypoint process which is needed to resolve [this `pack` issue](https://github.com/buildpacks/pack/issues/1034)

Signed-off-by: dwillist <dthornton@vmware.com>