### PR TITLE
Adds WithPlatform constructor option for initialization/manifest list querying values

### DIFF
--- a/image.go
+++ b/image.go
@@ -26,14 +26,11 @@ func (e SaveError) Error() string {
 	return fmt.Sprintf("failed to write image to the following tags: %s", strings.Join(errors, ","))
 }
 
-// Platform represents the target os/arch for an image. Type-castible to ggcr v1.Platform
+// Platform represents the target arch/os/os_version for an image construction and querying.
 type Platform struct {
 	Architecture string
 	OS           string
 	OSVersion    string
-	OSFeatures   []string
-	Variant      string
-	Features     []string
 }
 
 type Image interface {

--- a/image.go
+++ b/image.go
@@ -26,6 +26,16 @@ func (e SaveError) Error() string {
 	return fmt.Sprintf("failed to write image to the following tags: %s", strings.Join(errors, ","))
 }
 
+// Platform represents the target os/arch for an image. Type-castible to ggcr v1.Platform
+type Platform struct {
+	Architecture string
+	OS           string
+	OSVersion    string
+	OSFeatures   []string
+	Variant      string
+	Features     []string
+}
+
 type Image interface {
 	Name() string
 	Rename(name string)

--- a/local/local.go
+++ b/local/local.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -32,151 +31,120 @@ import (
 type Image struct {
 	docker           client.CommonAPIClient
 	repoName         string
-	platform         imgutil.Platform
 	inspect          types.ImageInspect
 	layerPaths       []string
 	prevImage        *Image // reused layers will be fetched from prevImage
 	downloadBaseOnce *sync.Once
 }
 
-type ImageOption func(*Image) (*Image, error)
-type InitialImageOption ImageOption
+type ImageOption func(*options) error
+
+type options struct {
+	platform          imgutil.Platform
+	baseImageRepoName string
+	prevImageRepoName string
+}
 
 func WithPreviousImage(imageName string) ImageOption {
-	return func(i *Image) (*Image, error) {
-		if _, err := inspectOptionalImage(i.docker, imageName, i.platform); err != nil {
-			return i, err
-		}
-
-		prevImage, err := NewImage(imageName, i.docker, FromBaseImage(imageName))
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get previous image '%s'", imageName)
-		}
-		i.prevImage = prevImage
-
-		return i, nil
+	return func(i *options) error {
+		i.prevImageRepoName = imageName
+		return nil
 	}
 }
 
 func FromBaseImage(imageName string) ImageOption {
-	return func(i *Image) (*Image, error) {
-		var (
-			err     error
-			inspect types.ImageInspect
-		)
-
-		if inspect, err = inspectOptionalImage(i.docker, imageName, i.platform); err != nil {
-			return i, err
-		}
-
-		i.inspect = inspect
-		i.layerPaths = make([]string, len(i.inspect.RootFS.Layers))
-
-		return i, nil
+	return func(i *options) error {
+		i.baseImageRepoName = imageName
+		return nil
 	}
 }
 
-func WithPlatform(platform imgutil.Platform) InitialImageOption {
-	return func(i *Image) (*Image, error) {
-		if platform.OS != "" && platform.OS != i.inspect.Os {
-			return nil, fmt.Errorf(`invalid os: platform os "%s" must match the daemon os "%s"`, platform.OS, i.inspect.Os)
-		}
-
-		i.inspect.Architecture = platform.Architecture
-		i.inspect.OsVersion = platform.OSVersion
-
+func WithPlatform(platform imgutil.Platform) ImageOption {
+	return func(i *options) error {
 		i.platform = platform
-
-		return i, nil
+		return nil
 	}
 }
 
-func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...interface{}) (*Image, error) {
-	var err error
+func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...ImageOption) (*Image, error) {
+	imageOpts := &options{}
+	for _, op := range ops {
+		if err := op(imageOpts); err != nil {
+			return nil, err
+		}
+	}
 
-	defaultPlatform, err := defaultPlatform(dockerClient)
+	platform, err := defaultPlatform(dockerClient)
 	if err != nil {
 		return nil, err
 	}
+	daemonOS := platform.OS
 
-	inspect := defaultInspect(defaultPlatform)
+	if (imageOpts.platform != imgutil.Platform{}) {
+		platform = imageOpts.platform
+	}
+
+	if imageOpts.platform.OS != "" && imageOpts.platform.OS != daemonOS {
+		return nil, fmt.Errorf(`invalid os: platform os "%s" must match the daemon os "%s"`, imageOpts.platform.OS, platform.OS)
+	}
+
+	inspect := defaultInspect(platform)
 
 	image := &Image{
 		docker:           dockerClient,
 		repoName:         repoName,
 		inspect:          inspect,
-		platform:         defaultPlatform,
 		layerPaths:       make([]string, len(inspect.RootFS.Layers)),
 		downloadBaseOnce: &sync.Once{},
 	}
 
-	image, err = processImageOptions(image, ops)
-	if err != nil {
-		return nil, err
+	if imageOpts.prevImageRepoName != "" {
+		// with previous image
+		if _, err := inspectOptionalImage(dockerClient, imageOpts.prevImageRepoName, platform); err != nil {
+			return nil, err
+		}
+
+		prevImage, err := NewImage(imageOpts.prevImageRepoName, dockerClient, FromBaseImage(imageOpts.prevImageRepoName))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get previous image '%s'", repoName)
+		}
+		image.prevImage = prevImage
 	}
 
-	image, err = prepareImage(image)
-	if err != nil {
-		return nil, err
+	if imageOpts.baseImageRepoName != "" {
+		if inspect, err = inspectOptionalImage(dockerClient, imageOpts.baseImageRepoName, platform); err != nil {
+			return nil, err
+		}
+
+		image.inspect = inspect
+		image.layerPaths = make([]string, len(image.inspect.RootFS.Layers))
 	}
 
-	return image, nil
-}
-
-func processImageOptions(image *Image, ops []interface{}) (*Image, error) {
-	sort.Slice(ops, func(i, _ int) bool {
-		switch ops[i].(type) {
-		case InitialImageOption:
-			return true
-		default:
-			return false
-		}
-	})
-
-	for _, op := range ops {
-		var err error
-
-		switch opFn := op.(type) {
-		case InitialImageOption:
-			image, err = opFn(image)
-		case ImageOption:
-			image, err = opFn(image)
-		}
+	if image.inspect.Os == "windows" && len(image.inspect.RootFS.Layers) == 0 {
+		layerReader, err := layer.WindowsBaseLayer()
 		if err != nil {
 			return nil, err
 		}
+
+		layerFile, err := ioutil.TempFile("", "imgutil.local.image.windowsbaselayer")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create temp file")
+		}
+		defer layerFile.Close()
+
+		hasher := sha256.New()
+
+		multiWriter := io.MultiWriter(layerFile, hasher)
+
+		if _, err := io.Copy(multiWriter, layerReader); err != nil {
+			return nil, errors.Wrap(err, "failed to copy base layer")
+		}
+
+		diffID := "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+
+		image.inspect.RootFS.Layers = append(image.inspect.RootFS.Layers, diffID)
+		image.layerPaths = append(image.layerPaths, layerFile.Name())
 	}
-	return image, nil
-}
-
-func prepareImage(image *Image) (*Image, error) {
-	if image.inspect.Os != "windows" || len(image.inspect.RootFS.Layers) != 0 {
-		return image, nil
-	}
-
-	layerReader, err := layer.WindowsBaseLayer()
-	if err != nil {
-		return nil, err
-	}
-
-	layerFile, err := ioutil.TempFile("", "imgutil.local.image.windowsbaselayer")
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create temp file")
-	}
-	defer layerFile.Close()
-
-	hasher := sha256.New()
-
-	multiWriter := io.MultiWriter(layerFile, hasher)
-
-	if _, err := io.Copy(multiWriter, layerReader); err != nil {
-		return nil, errors.Wrap(err, "failed to copy base layer")
-	}
-
-	diffID := "sha256:" + hex.EncodeToString(hasher.Sum(nil))
-
-	image.inspect.RootFS.Layers = append(image.inspect.RootFS.Layers, diffID)
-	image.layerPaths = append(image.layerPaths, layerFile.Name())
 
 	return image, nil
 }

--- a/local/local.go
+++ b/local/local.go
@@ -59,7 +59,7 @@ func FromBaseImage(imageName string) ImageOption {
 	}
 }
 
-func WithPlatform(platform imgutil.Platform) ImageOption {
+func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	return func(i *options) error {
 		i.platform = platform
 		return nil

--- a/local/local.go
+++ b/local/local.go
@@ -45,6 +45,9 @@ type options struct {
 	prevImageRepoName string
 }
 
+//WithPreviousImage loads an existing image as a source for reusable layers.
+//Use with ReuseLayer().
+//Ignored if image is not found.
 func WithPreviousImage(imageName string) ImageOption {
 	return func(i *options) error {
 		i.prevImageRepoName = imageName
@@ -52,6 +55,8 @@ func WithPreviousImage(imageName string) ImageOption {
 	}
 }
 
+//FromBaseImage loads an existing image as the config and layers for the new image.
+//Ignored if image is not found.
 func FromBaseImage(imageName string) ImageOption {
 	return func(i *options) error {
 		i.baseImageRepoName = imageName
@@ -59,6 +64,8 @@ func FromBaseImage(imageName string) ImageOption {
 	}
 }
 
+//WithDefaultPlatform provides Architecture/OS/OSVersion defaults for the new image.
+//Defaults for a new image are ignored when FromBaseImage returns an image.
 func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	return func(i *options) error {
 		i.platform = platform
@@ -66,6 +73,7 @@ func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	}
 }
 
+//NewImage returns a new Image that can be modified and saved to a registry.
 func NewImage(repoName string, dockerClient client.CommonAPIClient, ops ...ImageOption) (*Image, error) {
 	imageOpts := &options{}
 	for _, op := range ops {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -99,6 +99,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					dockerClient,
 					local.WithPlatform(imgutil.Platform{
 						Architecture: expectedArmArch,
+						OS:           daemonOS,
 						OSVersion:    expectedOSVersion,
 					}),
 				)

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1069,7 +1069,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), oldBase)
 				h.AssertNil(t, err)
-				oldTopLayer = inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
+				oldTopLayer = h.StringElementAt(inspect.RootFS.Layers, -1)
 
 				// original image
 				origImage, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(oldBase))
@@ -1107,16 +1107,16 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				beforeInspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
-				beforeOldBaseLayer1DiffID := beforeInspect.RootFS.Layers[len(beforeInspect.RootFS.Layers)-4]
+				beforeOldBaseLayer1DiffID := h.StringElementAt(beforeInspect.RootFS.Layers, -4)
 				h.AssertEq(t, oldBaseLayer1DiffID, beforeOldBaseLayer1DiffID)
 
-				beforeOldBaseLayer2DiffID := beforeInspect.RootFS.Layers[len(beforeInspect.RootFS.Layers)-3]
+				beforeOldBaseLayer2DiffID := h.StringElementAt(beforeInspect.RootFS.Layers, -3)
 				h.AssertEq(t, oldBaseLayer2DiffID, beforeOldBaseLayer2DiffID)
 
-				beforeLayer3DiffID := beforeInspect.RootFS.Layers[len(beforeInspect.RootFS.Layers)-2]
+				beforeLayer3DiffID := h.StringElementAt(beforeInspect.RootFS.Layers, -2)
 				h.AssertEq(t, imgLayer1DiffID, beforeLayer3DiffID)
 
-				beforeLayer4DiffID := beforeInspect.RootFS.Layers[len(beforeInspect.RootFS.Layers)-1]
+				beforeLayer4DiffID := h.StringElementAt(beforeInspect.RootFS.Layers, -1)
 				h.AssertEq(t, imgLayer2DiffID, beforeLayer4DiffID)
 
 				// Run rebase
@@ -1136,16 +1136,16 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				numLayers := len(afterInspect.RootFS.Layers)
 				h.AssertEq(t, numLayers, origNumLayers)
 
-				afterLayer1DiffID := afterInspect.RootFS.Layers[len(afterInspect.RootFS.Layers)-4]
+				afterLayer1DiffID := h.StringElementAt(afterInspect.RootFS.Layers, -4)
 				h.AssertEq(t, newBaseLayer1DiffID, afterLayer1DiffID)
 
-				afterLayer2DiffID := afterInspect.RootFS.Layers[len(afterInspect.RootFS.Layers)-3]
+				afterLayer2DiffID := h.StringElementAt(afterInspect.RootFS.Layers, -3)
 				h.AssertEq(t, newBaseLayer2DiffID, afterLayer2DiffID)
 
-				afterLayer3DiffID := afterInspect.RootFS.Layers[len(afterInspect.RootFS.Layers)-2]
+				afterLayer3DiffID := h.StringElementAt(afterInspect.RootFS.Layers, -2)
 				h.AssertEq(t, imgLayer1DiffID, afterLayer3DiffID)
 
-				afterLayer4DiffID := afterInspect.RootFS.Layers[len(afterInspect.RootFS.Layers)-1]
+				afterLayer4DiffID := h.StringElementAt(afterInspect.RootFS.Layers, -1)
 				h.AssertEq(t, imgLayer2DiffID, afterLayer4DiffID)
 
 				h.AssertEq(t, afterInspect.Os, beforeInspect.Os)
@@ -1181,7 +1181,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
-				expectedTopLayer = inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
+				expectedTopLayer = h.StringElementAt(inspect.RootFS.Layers, -1)
 			})
 
 			it.After(func() {
@@ -1238,7 +1238,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
-				h.AssertEq(t, newLayerDiffID, inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1])
+				h.AssertEq(t, newLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -1))
 			})
 		})
 
@@ -1288,8 +1288,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
-				h.AssertEq(t, oldLayerDiffID, inspect.RootFS.Layers[len(inspect.RootFS.Layers)-2])
-				h.AssertEq(t, newLayerDiffID, inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1])
+				h.AssertEq(t, oldLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -2))
+				h.AssertEq(t, newLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -1))
 			})
 		})
 	})
@@ -1337,8 +1337,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
-			h.AssertEq(t, oldLayerDiffID, inspect.RootFS.Layers[len(inspect.RootFS.Layers)-2])
-			h.AssertEq(t, newLayerDiffID, inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1])
+			h.AssertEq(t, oldLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -2))
+			h.AssertEq(t, newLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -1))
 		})
 	})
 
@@ -1454,8 +1454,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), prevName)
 			h.AssertNil(t, err)
 
-			prevLayer1SHA = inspect.RootFS.Layers[len(inspect.RootFS.Layers)-2]
-			prevLayer2SHA = inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
+			prevLayer1SHA = h.StringElementAt(inspect.RootFS.Layers, -2)
+			prevLayer2SHA = h.StringElementAt(inspect.RootFS.Layers, -1)
 		})
 
 		it.After(func() {
@@ -1485,8 +1485,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
-			newLayer1SHA := inspect.RootFS.Layers[len(inspect.RootFS.Layers)-2]
-			reusedLayer2SHA := inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
+			newLayer1SHA := h.StringElementAt(inspect.RootFS.Layers, -2)
+			reusedLayer2SHA := h.StringElementAt(inspect.RootFS.Layers, -1)
 
 			h.AssertNotEq(t, prevLayer1SHA, newLayer1SHA)
 			h.AssertEq(t, prevLayer2SHA, reusedLayer2SHA)
@@ -1514,7 +1514,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(inspect.RootFS.Layers), 1)
 			}
 
-			newLayer1SHA := inspect.RootFS.Layers[len(inspect.RootFS.Layers)-1]
+			newLayer1SHA := h.StringElementAt(inspect.RootFS.Layers, -1)
 
 			h.AssertEq(t, prevLayer1SHA, newLayer1SHA)
 		})

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -84,7 +84,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("#WithPlatform", func() {
+		when("#WithDefaultPlatform", func() {
 			it("sets all available platform fields", func() {
 				expectedArmArch := "arm64"
 				expectedOSVersion := ""
@@ -97,7 +97,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				img, err := local.NewImage(
 					newTestImageName(),
 					dockerClient,
-					local.WithPlatform(imgutil.Platform{
+					local.WithDefaultPlatform(imgutil.Platform{
 						Architecture: expectedArmArch,
 						OS:           daemonOS,
 						OSVersion:    expectedOSVersion,
@@ -241,7 +241,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("#WithPlatform", func() {
+			when("#WithDefaultPlatform", func() {
 				when("base image and platform architecture/OS do not match", func() {
 					it("uses the base image architecture/OS, ignoring platform", func() {
 						// linux/arm64 busybox image
@@ -261,7 +261,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							newTestImageName(),
 							dockerClient,
 							local.FromBaseImage(armBaseImageName),
-							local.WithPlatform(imgutil.Platform{
+							local.WithDefaultPlatform(imgutil.Platform{
 								Architecture: "not-an-arch",
 								OSVersion:    "10.0.99999.9999",
 							}),
@@ -286,7 +286,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							newTestImageName(),
 							dockerClient,
 							local.FromBaseImage("some-bad-repo-name"),
-							local.WithPlatform(imgutil.Platform{
+							local.WithDefaultPlatform(imgutil.Platform{
 								Architecture: "arm64",
 								OS:           daemonOS,
 								OSVersion:    "10.0.99999.9999",
@@ -355,12 +355,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, img.ReuseLayer(existingLayerSHA))
 				})
 
-				it("provides reusable layers, ignoring WithPlatform", func() {
+				it("provides reusable layers, ignoring WithDefaultPlatform", func() {
 					img, err := local.NewImage(
 						newTestImageName(),
 						dockerClient,
 						local.WithPreviousImage(armBaseImageName),
-						local.WithPlatform(imgutil.Platform{
+						local.WithDefaultPlatform(imgutil.Platform{
 							Architecture: "some-fake-os",
 						}),
 					)

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -173,7 +173,13 @@ func newV1Image(keychain authn.Keychain, repoName string, platform imgutil.Platf
 		return nil, err
 	}
 
-	image, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport), remote.WithPlatform(v1.Platform(platform)))
+	v1Platform := v1.Platform{
+		Architecture: platform.Architecture,
+		OS:           platform.OS,
+		OSVersion:    platform.OSVersion,
+	}
+
+	image, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport), remote.WithPlatform(v1Platform))
 	if err != nil {
 		if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {
 			switch transportErr.StatusCode {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -52,7 +52,7 @@ func FromBaseImage(imageName string) ImageOption {
 	}
 }
 
-func WithPlatform(platform imgutil.Platform) ImageOption {
+func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	return func(opts *options) error {
 		opts.platform = platform
 		return nil

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -38,6 +38,9 @@ type options struct {
 
 type ImageOption func(*options) error
 
+//WithPreviousImage loads an existing image as a source for reusable layers.
+//Use with ReuseLayer().
+//Ignored if image is not found.
 func WithPreviousImage(imageName string) ImageOption {
 	return func(opts *options) error {
 		opts.prevImageRepoName = imageName
@@ -45,6 +48,8 @@ func WithPreviousImage(imageName string) ImageOption {
 	}
 }
 
+//FromBaseImage loads an existing image as the config and layers for the new image.
+//Ignored if image is not found.
 func FromBaseImage(imageName string) ImageOption {
 	return func(opts *options) error {
 		opts.baseImageRepoName = imageName
@@ -52,6 +57,9 @@ func FromBaseImage(imageName string) ImageOption {
 	}
 }
 
+//WithDefaultPlatform provides Architecture/OS/OSVersion defaults for the new image.
+//Defaults for a new image are ignored when FromBaseImage returns an image.
+//FromBaseImage and WithPreviousImage will use the platform to choose an image from a manifest list.
 func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	return func(opts *options) error {
 		opts.platform = platform
@@ -59,6 +67,7 @@ func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	}
 }
 
+//NewImage returns a new Image that can be modified and saved to a Docker daemon.
 func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (*Image, error) {
 	imageOpts := &options{}
 	for _, op := range ops {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -79,12 +79,12 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("#WithPlatform", func() {
+		when("#WithDefaultPlatform", func() {
 			it("sets all platform required fields for windows", func() {
 				img, err := remote.NewImage(
 					newTestImageName(),
 					authn.DefaultKeychain,
-					remote.WithPlatform(imgutil.Platform{
+					remote.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "windows",
 						OSVersion:    "10.0.17763.316",
@@ -116,7 +116,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				img, err := remote.NewImage(
 					newTestImageName(),
 					authn.DefaultKeychain,
-					remote.WithPlatform(imgutil.Platform{
+					remote.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "linux",
 					}),
@@ -243,7 +243,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("#WithPlatform", func() {
+			when("#WithDefaultPlatform", func() {
 				when("base image is an individual image manifest", func() {
 					when("platform matches image values", func() {
 						it("returns the base image", func() {
@@ -254,7 +254,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 								repoName,
 								authn.DefaultKeychain,
 								remote.FromBaseImage(windowsImageManifestName),
-								remote.WithPlatform(imgutil.Platform{
+								remote.WithDefaultPlatform(imgutil.Platform{
 									Architecture: "amd64",
 									OS:           "windows",
 									OSVersion:    "10.0.17763.1397",
@@ -285,7 +285,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 								repoName,
 								authn.DefaultKeychain,
 								remote.FromBaseImage(windowsImageManifestName),
-								remote.WithPlatform(imgutil.Platform{
+								remote.WithDefaultPlatform(imgutil.Platform{
 									OS:           "linux",
 									Architecture: "arm",
 								}),
@@ -316,7 +316,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 								repoName,
 								authn.DefaultKeychain,
 								remote.FromBaseImage(manifestListName),
-								remote.WithPlatform(imgutil.Platform{
+								remote.WithDefaultPlatform(imgutil.Platform{
 									OS:           "linux",
 									Architecture: "amd64",
 								}),
@@ -341,7 +341,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 								repoName,
 								authn.DefaultKeychain,
 								remote.FromBaseImage(manifestListName),
-								remote.WithPlatform(imgutil.Platform{
+								remote.WithDefaultPlatform(imgutil.Platform{
 									OS:           "windows",
 									Architecture: "arm",
 								}),
@@ -376,7 +376,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							repoName,
 							authn.DefaultKeychain,
 							remote.FromBaseImage("some-bad-repo-name"),
-							remote.WithPlatform(imgutil.Platform{
+							remote.WithDefaultPlatform(imgutil.Platform{
 								Architecture: "arm",
 								OS:           "linux",
 							}),
@@ -405,7 +405,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							repoName,
 							authn.DefaultKeychain,
 							remote.FromBaseImage("some-bad-repo-name"),
-							remote.WithPlatform(imgutil.Platform{
+							remote.WithDefaultPlatform(imgutil.Platform{
 								Architecture: "arm",
 								OS:           "windows",
 								OSVersion:    "10.0.99999.9999",
@@ -453,7 +453,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, img.ReuseLayer(existingLayerSha))
 				})
 
-				when("#WithPlatform", func() {
+				when("#WithDefaultPlatform", func() {
 					it("provides reusable layers from image in a manifest list with specific platform", func() {
 						manifestListName := "golang:1.13.8"
 						existingLayerSha := "sha256:cba908afa240240fceb312eb682bd7660fd5a404ddfd22843852dfdef141314b"
@@ -462,7 +462,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							repoName,
 							authn.DefaultKeychain,
 							remote.WithPreviousImage(manifestListName),
-							remote.WithPlatform(imgutil.Platform{
+							remote.WithDefaultPlatform(imgutil.Platform{
 								OS:           "windows",
 								Architecture: "amd64",
 							}),

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1166,8 +1166,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			manifestLayerDiffIDs := h.FetchManifestLayers(t, repoName)
 
-			h.AssertEq(t, oldLayerDiffID, manifestLayerDiffIDs[len(manifestLayerDiffIDs)-2])
-			h.AssertEq(t, newLayerDiffID, manifestLayerDiffIDs[len(manifestLayerDiffIDs)-1])
+			h.AssertEq(t, oldLayerDiffID, h.StringElementAt(manifestLayerDiffIDs, -2))
+			h.AssertEq(t, newLayerDiffID, h.StringElementAt(manifestLayerDiffIDs, -1))
 		})
 	})
 
@@ -1208,8 +1208,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			manifestLayerDiffIDs := h.FetchManifestLayers(t, repoName)
 
-			h.AssertEq(t, oldLayerDiffID, manifestLayerDiffIDs[len(manifestLayerDiffIDs)-2])
-			h.AssertEq(t, newLayerDiffID, manifestLayerDiffIDs[len(manifestLayerDiffIDs)-1])
+			h.AssertEq(t, oldLayerDiffID, h.StringElementAt(manifestLayerDiffIDs, -2))
+			h.AssertEq(t, newLayerDiffID, h.StringElementAt(manifestLayerDiffIDs, -1))
 		})
 	})
 
@@ -1268,8 +1268,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				manifestLayers := h.FetchManifestLayers(t, repoName)
 
-				newLayer1SHA := manifestLayers[len(manifestLayers)-2]
-				reusedLayer2SHA := manifestLayers[len(manifestLayers)-1]
+				newLayer1SHA := h.StringElementAt(manifestLayers, -2)
+				reusedLayer2SHA := h.StringElementAt(manifestLayers, -1)
 
 				h.AssertNotEq(t, prevLayer1SHA, newLayer1SHA)
 				h.AssertEq(t, prevLayer2SHA, reusedLayer2SHA)

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -436,8 +436,45 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("#WithPreviousImage", func() {
+			when("previous image is exists", func() {
+				it("provides reusable layers", func() {
+					baseImageName := "arm64v8/busybox@sha256:50edf1d080946c6a76989d1c3b0e753b62f7d9b5f5e66e88bef23ebbd1e9709c"
+					existingLayerSha := "sha256:5a0b973aa300cd2650869fd76d8546b361fcd6dfc77bd37b9d4f082cca9874e4"
+
+					img, err := remote.NewImage(
+						repoName,
+						authn.DefaultKeychain,
+						remote.WithPreviousImage(baseImageName),
+					)
+
+					h.AssertNil(t, err)
+
+					h.AssertNil(t, img.ReuseLayer(existingLayerSha))
+				})
+
+				when("#WithPlatform", func() {
+					it("provides reusable layers from image in a manifest list with specific platform", func() {
+						manifestListName := "golang:1.13.8"
+						existingLayerSha := "sha256:cba908afa240240fceb312eb682bd7660fd5a404ddfd22843852dfdef141314b"
+
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.WithPreviousImage(manifestListName),
+							remote.WithPlatform(imgutil.Platform{
+								OS:           "windows",
+								Architecture: "amd64",
+							}),
+						)
+						h.AssertNil(t, err)
+
+						h.AssertNil(t, img.ReuseLayer(existingLayerSha))
+					})
+				})
+			})
+
 			when("previous image does not exist", func() {
-				it("don't error", func() {
+				it("does not error", func() {
 					_, err := remote.NewImage(
 						repoName,
 						authn.DefaultKeychain,

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -52,8 +52,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		repoName = newTestImageName()
 	})
 
-	when("#NewRemote", func() {
-		when("no base image is given", func() {
+	when("#NewImage", func() {
+		when("no base image or platform is given", func() {
 			it("returns an empty image", func() {
 				_, err := remote.NewImage(newTestImageName(), authn.DefaultKeychain)
 				h.AssertNil(t, err)
@@ -79,66 +79,126 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("#FromRemoteBaseImage", func() {
-			when("base image exists", func() {
-				it("sets the initial state from a linux/arm base image", func() {
-					baseImageName := "arm64v8/busybox@sha256:50edf1d080946c6a76989d1c3b0e753b62f7d9b5f5e66e88bef23ebbd1e9709c"
-					existingLayerSha := "sha256:5a0b973aa300cd2650869fd76d8546b361fcd6dfc77bd37b9d4f082cca9874e4"
+		when("#WithPlatform", func() {
+			it("sets all platform required fields for windows", func() {
+				img, err := remote.NewImage(
+					newTestImageName(),
+					authn.DefaultKeychain,
+					remote.WithPlatform(imgutil.Platform{
+						Architecture: "arm",
+						OS:           "windows",
+						OSVersion:    "10.0.17763.316",
+					}),
+				)
+				h.AssertNil(t, err)
+				h.AssertNil(t, img.Save())
 
-					img, err := remote.NewImage(
-						repoName,
-						authn.DefaultKeychain,
-						remote.FromBaseImage(baseImageName),
-					)
-					h.AssertNil(t, err)
+				arch, err := img.Architecture()
+				h.AssertNil(t, err)
+				h.AssertEq(t, arch, "arm")
 
-					os, err := img.OS()
-					h.AssertNil(t, err)
-					h.AssertEq(t, os, "linux")
+				os, err := img.OS()
+				h.AssertNil(t, err)
+				h.AssertEq(t, os, "windows")
 
-					osVersion, err := img.OSVersion()
-					h.AssertNil(t, err)
-					h.AssertEq(t, osVersion, "")
+				osVersion, err := img.OSVersion()
+				h.AssertNil(t, err)
+				h.AssertEq(t, osVersion, "10.0.17763.316")
 
-					arch, err := img.Architecture()
-					h.AssertNil(t, err)
-					h.AssertEq(t, arch, "arm64")
+				//base layer is added for windows
+				topLayerDiffID, err := img.TopLayer()
+				h.AssertNil(t, err)
 
-					readCloser, err := img.GetLayer(existingLayerSha)
-					h.AssertNil(t, err)
-					defer readCloser.Close()
-				})
+				h.AssertNotEq(t, topLayerDiffID, "")
+			})
 
-				it("sets the initial state from a windows/amd64 base image", func() {
-					baseImageName := "mcr.microsoft.com/windows/nanoserver@sha256:06281772b6a561411d4b338820d94ab1028fdeb076c85350bbc01e80c4bfa2b4"
-					existingLayerSha := "sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e"
+			it("sets all platform required fields for linux", func() {
+				img, err := remote.NewImage(
+					newTestImageName(),
+					authn.DefaultKeychain,
+					remote.WithPlatform(imgutil.Platform{
+						Architecture: "arm",
+						OS:           "linux",
+					}),
+				)
+				h.AssertNil(t, err)
+				h.AssertNil(t, img.Save())
 
-					img, err := remote.NewImage(
-						repoName,
-						authn.DefaultKeychain,
-						remote.FromBaseImage(baseImageName),
-					)
-					h.AssertNil(t, err)
+				arch, err := img.Architecture()
+				h.AssertNil(t, err)
+				h.AssertEq(t, arch, "arm")
 
-					os, err := img.OS()
-					h.AssertNil(t, err)
-					h.AssertEq(t, os, "windows")
+				os, err := img.OS()
+				h.AssertNil(t, err)
+				h.AssertEq(t, os, "linux")
 
-					osVersion, err := img.OSVersion()
-					h.AssertNil(t, err)
-					h.AssertEq(t, osVersion, "10.0.17763.1040")
+				_, err = img.TopLayer()
+				h.AssertError(t, err, "has no layers")
+			})
+		})
 
-					arch, err := img.Architecture()
-					h.AssertNil(t, err)
-					h.AssertEq(t, arch, "amd64")
+		when("#FromBaseImage", func() {
+			when("no platform is specified", func() {
+				when("base image is an individual image manifest", func() {
+					it("sets the initial state from a linux/arm base image", func() {
+						baseImageName := "arm64v8/busybox@sha256:50edf1d080946c6a76989d1c3b0e753b62f7d9b5f5e66e88bef23ebbd1e9709c"
+						existingLayerSha := "sha256:5a0b973aa300cd2650869fd76d8546b361fcd6dfc77bd37b9d4f082cca9874e4"
 
-					readCloser, err := img.GetLayer(existingLayerSha)
-					h.AssertNil(t, err)
-					defer readCloser.Close()
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage(baseImageName),
+						)
+						h.AssertNil(t, err)
+
+						os, err := img.OS()
+						h.AssertNil(t, err)
+						h.AssertEq(t, os, "linux")
+
+						osVersion, err := img.OSVersion()
+						h.AssertNil(t, err)
+						h.AssertEq(t, osVersion, "")
+
+						arch, err := img.Architecture()
+						h.AssertNil(t, err)
+						h.AssertEq(t, arch, "arm64")
+
+						readCloser, err := img.GetLayer(existingLayerSha)
+						h.AssertNil(t, err)
+						defer readCloser.Close()
+					})
+
+					it("sets the initial state from a windows/amd64 base image", func() {
+						baseImageName := "mcr.microsoft.com/windows/nanoserver@sha256:06281772b6a561411d4b338820d94ab1028fdeb076c85350bbc01e80c4bfa2b4"
+						existingLayerSha := "sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e"
+
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage(baseImageName),
+						)
+						h.AssertNil(t, err)
+
+						os, err := img.OS()
+						h.AssertNil(t, err)
+						h.AssertEq(t, os, "windows")
+
+						osVersion, err := img.OSVersion()
+						h.AssertNil(t, err)
+						h.AssertEq(t, osVersion, "10.0.17763.1040")
+
+						arch, err := img.Architecture()
+						h.AssertNil(t, err)
+						h.AssertEq(t, arch, "amd64")
+
+						readCloser, err := img.GetLayer(existingLayerSha)
+						h.AssertNil(t, err)
+						defer readCloser.Close()
+					})
 				})
 
 				when("base image is a multi-OS/Arch manifest list", func() {
-					it("returns a base image matching the runtime GOOS/GOARCH", func() {
+					it("returns a base image matching linux/amd64", func() {
 						manifestListName := "golang:1.13.8"
 						existingLayerSha := "sha256:427da4a135b0869c1a274ba38e23d45bdbda93134c4ad99c8900cb0cfe9f0c9e"
 
@@ -166,17 +226,211 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						defer readCloser.Close()
 					})
 				})
+
+				when("base image does not exist", func() {
+					it("returns an empty image", func() {
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage("some-bad-repo-name"),
+						)
+
+						h.AssertNil(t, err)
+
+						_, err = img.TopLayer()
+						h.AssertError(t, err, "has no layers")
+					})
+				})
 			})
 
-			when("base image does not exist", func() {
-				it("don't error", func() {
-					_, err := remote.NewImage(
-						repoName,
-						authn.DefaultKeychain,
-						remote.FromBaseImage("some-bad-repo-name"),
-					)
+			when("#WithPlatform", func() {
+				when("base image is an individual image manifest", func() {
+					when("platform matches image values", func() {
+						it("returns the base image", func() {
+							// "golang:1.15.0-nanoserver-1809" image manifest (windows/amd64/10.0.17763.1397)
+							windowsImageManifestName := "golang@sha256:6c09e9b9ca3aa2e939c8d0e695d6378f31d42c2473fd57293ba03c254257d9e3"
 
-					h.AssertNil(t, err)
+							img, err := remote.NewImage(
+								repoName,
+								authn.DefaultKeychain,
+								remote.FromBaseImage(windowsImageManifestName),
+								remote.WithPlatform(imgutil.Platform{
+									OS:           "windows",
+									Architecture: "amd64",
+								}),
+							)
+							h.AssertNil(t, err)
+
+							arch, err := img.Architecture()
+							h.AssertNil(t, err)
+							h.AssertEq(t, arch, "amd64")
+
+							os, err := img.OS()
+							h.AssertNil(t, err)
+							h.AssertEq(t, os, "windows")
+
+							osVersion, err := img.OSVersion()
+							h.AssertNil(t, err)
+							h.AssertEq(t, osVersion, "10.0.17763.1397")
+						})
+					})
+
+					when("platform conflicts with image values", func() {
+						it("returns the base image, regardless of platform values", func() {
+							// "golang:1.15.0-nanoserver-1809" image manifest (windows/amd64/10.0.17763.1397)
+							windowsImageManifestName := "golang@sha256:6c09e9b9ca3aa2e939c8d0e695d6378f31d42c2473fd57293ba03c254257d9e3"
+
+							img, err := remote.NewImage(
+								repoName,
+								authn.DefaultKeychain,
+								remote.FromBaseImage(windowsImageManifestName),
+								remote.WithPlatform(imgutil.Platform{
+									OS:           "linux",
+									Architecture: "arm",
+								}),
+							)
+							h.AssertNil(t, err)
+
+							arch, err := img.Architecture()
+							h.AssertNil(t, err)
+							h.AssertEq(t, arch, "amd64")
+
+							os, err := img.OS()
+							h.AssertNil(t, err)
+							h.AssertEq(t, os, "windows")
+
+							osVersion, err := img.OSVersion()
+							h.AssertNil(t, err)
+							h.AssertEq(t, osVersion, "10.0.17763.1397")
+						})
+					})
+				})
+
+				when("base image is a multi-OS/Arch manifest list", func() {
+					when("image with matching platform fields exists", func() {
+						it("returns the image whose index matches the platform", func() {
+							manifestListName := "golang:1.13.8"
+
+							img, err := remote.NewImage(
+								repoName,
+								authn.DefaultKeychain,
+								remote.FromBaseImage(manifestListName),
+								remote.WithPlatform(imgutil.Platform{
+									OS:           "linux",
+									Architecture: "amd64",
+								}),
+							)
+							h.AssertNil(t, err)
+
+							arch, err := img.Architecture()
+							h.AssertNil(t, err)
+							h.AssertEq(t, arch, "amd64")
+
+							os, err := img.OS()
+							h.AssertNil(t, err)
+							h.AssertEq(t, os, "linux")
+						})
+					})
+
+					when("no image with matching platform exists", func() {
+						it("returns an empty image with platform fields set", func() {
+							manifestListName := "golang:1.13.8"
+
+							img, err := remote.NewImage(
+								repoName,
+								authn.DefaultKeychain,
+								remote.FromBaseImage(manifestListName),
+								remote.WithPlatform(imgutil.Platform{
+									OS:           "windows",
+									Architecture: "arm",
+								}),
+							)
+
+							h.AssertNil(t, err)
+
+							arch, err := img.Architecture()
+							h.AssertNil(t, err)
+							h.AssertEq(t, arch, "arm")
+
+							os, err := img.OS()
+							h.AssertNil(t, err)
+							h.AssertEq(t, os, "windows")
+
+							osVersion, err := img.OSVersion()
+							h.AssertNil(t, err)
+							h.AssertEq(t, osVersion, "")
+
+							// base layer is added for Windows
+							topLayerDiffID, err := img.TopLayer()
+							h.AssertNil(t, err)
+
+							h.AssertNotEq(t, topLayerDiffID, "")
+						})
+					})
+				})
+
+				when("base image does not exist", func() {
+					it("returns an empty linux image based on platform fields", func() {
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage("some-bad-repo-name"),
+							remote.WithPlatform(imgutil.Platform{
+								Architecture: "arm",
+								OS:           "linux",
+							}),
+						)
+
+						h.AssertNil(t, err)
+
+						arch, err := img.Architecture()
+						h.AssertNil(t, err)
+						h.AssertEq(t, arch, "arm")
+
+						os, err := img.OS()
+						h.AssertNil(t, err)
+						h.AssertEq(t, os, "linux")
+
+						osVersion, err := img.OSVersion()
+						h.AssertNil(t, err)
+						h.AssertEq(t, osVersion, "")
+
+						_, err = img.TopLayer()
+						h.AssertError(t, err, "has no layers")
+					})
+
+					it("returns an empty windows image based on platform fields", func() {
+						img, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage("some-bad-repo-name"),
+							remote.WithPlatform(imgutil.Platform{
+								Architecture: "arm",
+								OS:           "windows",
+								OSVersion:    "10.0.99999.9999",
+							}),
+						)
+
+						h.AssertNil(t, err)
+
+						arch, err := img.Architecture()
+						h.AssertNil(t, err)
+						h.AssertEq(t, arch, "arm")
+
+						os, err := img.OS()
+						h.AssertNil(t, err)
+						h.AssertEq(t, os, "windows")
+
+						osVersion, err := img.OSVersion()
+						h.AssertNil(t, err)
+						h.AssertEq(t, osVersion, "10.0.99999.9999")
+
+						//base layer is added for windows
+						topLayerDiffID, err := img.TopLayer()
+						h.AssertNil(t, err)
+
+						h.AssertNotEq(t, topLayerDiffID, "")
+					})
 				})
 			})
 		})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -255,8 +255,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 								authn.DefaultKeychain,
 								remote.FromBaseImage(windowsImageManifestName),
 								remote.WithPlatform(imgutil.Platform{
-									OS:           "windows",
 									Architecture: "amd64",
+									OS:           "windows",
+									OSVersion:    "10.0.17763.1397",
 								}),
 							)
 							h.AssertNil(t, err)

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -285,20 +285,6 @@ func CreateSingleFileLayerTar(layerPath, txt, osType string) (string, error) {
 	return tarFile.Name(), nil
 }
 
-func WindowsBaseLayer(t *testing.T) string {
-	tarFile, err := ioutil.TempFile("", "windows-base-layer.tar")
-	AssertNil(t, err)
-	defer tarFile.Close()
-
-	baseLayer, err := layer.WindowsBaseLayer()
-	AssertNil(t, err)
-
-	_, err = io.Copy(tarFile, baseLayer)
-	AssertNil(t, err)
-
-	return tarFile.Name()
-}
-
 func FetchManifestLayers(t *testing.T, repoName string) []string {
 	t.Helper()
 
@@ -368,4 +354,11 @@ func RunnableBaseImage(os string) string {
 		return "mcr.microsoft.com/windows/nanoserver@sha256:08c883692e527b2bb4d7f6579e7707a30a2aaa66556b265b917177565fd76117"
 	}
 	return "busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"
+}
+
+func StringElementAt(elements []string, offset int) string {
+	if offset < 0 {
+		return elements[len(elements)+offset]
+	}
+	return elements[offset]
 }


### PR DESCRIPTION
The changes in this PR are to introduce a `WithPlatform()` option for `NewImage()` to make it easier to override the default `Architecture`/`OS`/`OSVersion` with alternate values in new images and querying manifest lists with `FromBaseImage` or `WithPreviousImage`. Imgutil `NewImage()` currently creates new images with a default of [linux/amd64](https://github.com/buildpacks/imgutil/blob/30601e371ce385a990992de9ed9ff7b373f7c524/remote/remote.go#L108) for `remote` and [daemon OS/amd64](https://github.com/buildpacks/imgutil/blob/30601e371ce385a990992de9ed9ff7b373f7c524/local/local.go#L675) for `local`, and when using `remote.FromBaseImage()` or `remote.WithPreviousImage()`, it queries manifest lists preferring [linux/amd64](https://github.com/google/go-containerregistry/blob/9c81ed02c3b521bea5c56ddc2698f37a788b176f/pkg/v1/remote/options.go#L42) as inherited from `go-containerregistry`. 

The new implementation attempts to be additive and optional, preserving existing behavior (with an exception on Windows¹) but enabling some new scenarios:

* Initialize a new empty image with Architecture/OS/OSVersion:
    `remote`
    ```golang
    img, err := remote.NewImage(
	    "gcr.io/my-new-linux-arm-image:latest",
	    authn.DefaultKeychain,
	    remote.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "linux",
	    }),
    )
    ...
    img.Architecture() // => "arm"
    img.OS()           // => "linux"
    ```
    `local` with a windows/amd64 daemon
    ```golang
    img, err := local.NewImage(
	    "gcr.io/my-new-windows-arm-image:latest",
	    dockerClient,
	    local.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "windows",
		    OSVersion:    "10.0.999",
	    }),
    )
    ...
    img.Architecture() // => "arm"
    img.OS()           // => "windows"
    img.OSVersion()    // => "10.0.999"
    ```

* Initialize a new remote image from a base image in multi-arch/os manifest list:
    ```golang
    img, err := remote.NewImage(
	    "gcr.io/my-new-linux-arm-image:latest",
	    authn.DefaultKeychain,
	    remote.FromBaseImage("golang:1.15"), // golang manifest list (contains matching linux/arm image)
	    remote.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "linux",
	    }),
    )
    ...
    img.Architecture() // => "arm"
    img.OS()           // => "linux"
    ```

* Initialize a new empty image when manifest list doesn't contain image manifest for requested platform:
    ```golang
    img, err := remote.NewImage(
	    "gcr.io/my-new-windows-arm-image:latest",
	    authn.DefaultKeychain,
	    remote.FromBaseImage("golang:1.15"),  // golang manifest list (has no windows/arm image)
	    remote.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "windows",
	    }),
    )
    ...
    img.Architecture() => "arm"
    img.OS() => "windows"
    ```


There is additional behavior that is intended to stay as close as possible to existing behavior for `NewImage()` and `FromBaseImage()`, but may nevertheless be surprising:

* A single image manifest result for `FromBaseImage()` is always used, even when it doesn't match the `WithPlatform()` values
    ```golang
    img, err := remote.NewImage(
	    "gcr.io/my-supposedly-windows-arm-image:latest",
	    authn.DefaultKeychain,
	    remote.FromBaseImage("amd64/golang:1.15"),  // linux/amd64 image manifest
	    remote.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "windows",
	    }),
    )
    ...
    img.Architecture() => "amd64"
    img.OS() => "linux"
    ```
    
    ```golang
    // with a windows/amd64 daemon
    img, err := local.NewImage(
	    "gcr.io/my-supposedly-windows-arm-image:latest",
	    authn.DefaultKeychain,
	    remote.FromBaseImage("winamd64/golang:1.15"),  // locally pulled windows/amd64 image
	    remote.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "windows",
	    }),
    )
    ...
    img.Architecture() => "amd64"
    img.OS() => "windows"
    ```
    
    The reasoning for this behavior is that `WithPlatform()` should primarily be used to assign values to a new image when nothing is inherited - when either no `FromBaseImage()` is given or when the `FromBaseImage()` image is not found. It's secondary purpose is for `remote`'s special edge-case when `FromBaseImage()` needs a manifest list tie-breaker. It shouldn't be treated as a constraint or validator. This approach also follows `ggcr/remote.Image()`, which currently [only uses](https://github.com/google/go-containerregistry/blob/51f01e739161bf35d663240a8ca404777d7d9378/pkg/v1/remote/descriptor.go#L152-L156) it's own `ggcr/remote.WithPlatform()` option when the `ref` is a manifest list, and disregards it for single image manifests even when the platform and image conflict.
    
    In addition to deviating from `ggcr`, the potential alternative approaches I looked into all had downsides:
    * If it returned the base image with the platform values clobbered, it would be difficult for a consumer to figure out what happened and message a user.
    * If it were to ignore the base image result and return an empty image based on the platform values, it would also be difficult to for consumers to deduce what happened since the image ref was otherwise valid.
    * If it were to return an error, we'd need to add custom filtering and error conditions. Not returning an image could potentially prevent consumers from implementing their own filtering/validation after `NewImage` is called. For consumers currently using `NewImage()` and accepting all image platforms, new errors could make backward compatibility challenging, if they only want `WithPlatform` for manifest list tie-breaking and new image defaults.
    
    With the PR approach, consumers can hopefully compare the returned image with their desired platform, and throw an appropriate error if needed. I'm sure there are other considerations though so I'm open for feedback on this.

    
* ¹ New empty Windows images are always initialized with minimal Windows base layers (https://github.com/buildpacks/imgutil/pull/64)

    ```golang
    // with a windows/amd64 daemon
    img, err := local.NewImage(
	    "gcr.io/my-new-windows-arm-image:latest",
	    dockerClient,
	    local.WithPlatform(imgutil.Platform{
		    Architecture: "arm",
		    OS:           "windows",
		    OSVersion:    "10.0.999",
	    }),
    )
    ...
    img.Architecture() // => "arm"
    img.OS()           // => "windows"
    img.OSVersion()    // => "10.0.999"
    len(image.Layers()) // => 1
    ```

    A Windows image cannot be pulled or stored on a daemon without a valid base layer - either from a Microsoft-authored base image or one from `layer.WindowsBaseLayer()`. To simplify new image creation, `NewImage()` now adds one based on `layer.WindowsBaseLayer()`, when `FromBaseImage()` is not used or returns an empty image. This will allow Linux and Windows to behave much more consistently and hopefully hides away this implementation detail for most consumers. It could also allow us to deprecate the shim base layer if it becomes unnecessary.
    
    It is a breaking change for all Windows consumers that already externally add their own base layer with `layer.WindowsBaseLayer()` and `AddLayer()` since that will effectively add it twice. This should be acceptable since it's only known to be used in `pack` which has it behind an experimental flag. Additionally, this new functionality should likely have been included in the original implementation but was blocked on the missing `WithPlatform` support. It is included in the PR since it's the driver for this `WithPlatform` implementation (https://github.com/buildpacks/lifecycle/pull/532), though can be separated out if needed.