### PR TITLE
Changes registry test helper to support non-localhost

### DIFF
--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -21,10 +21,10 @@ import (
 	h "github.com/buildpacks/imgutil/testhelpers"
 )
 
-var registryPort string
+var registryHost, registryPort string
 
 func newTestImageName() string {
-	return "localhost:" + registryPort + "/imgutil-acceptance-" + h.RandString(10)
+	return registryHost + ":" + registryPort + "/imgutil-acceptance-" + h.RandString(10)
 }
 
 func TestAcceptance(t *testing.T) {
@@ -34,6 +34,7 @@ func TestAcceptance(t *testing.T) {
 	dockerRegistry.Start(t)
 	defer dockerRegistry.Stop(t)
 
+	registryHost = dockerRegistry.Host
 	registryPort = dockerRegistry.Port
 
 	spec.Run(t, "Reproducibility", testReproducibility, spec.Sequential(), spec.Report(report.Terminal{}))

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -35,7 +35,7 @@ func TestLocal(t *testing.T) {
 }
 
 func newTestImageName() string {
-	return "localhost:" + localTestRegistry.Port + "/pack-image-test-" + h.RandString(10)
+	return localTestRegistry.Host + ":" + localTestRegistry.Port + "/pack-image-test-" + h.RandString(10)
 }
 
 func testImage(t *testing.T, when spec.G, it spec.S) {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -35,7 +35,7 @@ func TestLocal(t *testing.T) {
 }
 
 func newTestImageName() string {
-	return localTestRegistry.Host + ":" + localTestRegistry.Port + "/pack-image-test-" + h.RandString(10)
+	return localTestRegistry.RepoName("pack-image-test-" + h.RandString(10))
 }
 
 func testImage(t *testing.T, when spec.G, it spec.S) {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1343,10 +1343,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				name, err := name.ParseReference(repoName, name.WeakValidation)
+				//convert authenticated repo name to unauthenticated repo name
+				authRepoRef, err := name.ParseReference(repoName, name.WeakValidation)
 				h.AssertNil(t, err)
-				imageName := name.Context().RepositoryStr()
-				readonlyRepoName := readonlyDockerRegistry.RepoName(imageName)
+				sharedImageName := authRepoRef.Context().RepositoryStr()
+				readonlyRepoName := readonlyDockerRegistry.RepoName(sharedImageName)
 
 				testImg, err := remote.NewImage(
 					"test",

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -104,7 +104,7 @@ func (r *DockerRegistry) Start(t *testing.T) {
 	var volumeBinds []string
 	var containerUser string
 	if r.volumeName != "" {
-		// try to create volumes that do not exist
+		// try to create volumes that may exist
 		_, err := DockerCli(t).VolumeCreate(context.Background(), volumetypes.VolumeCreateBody{Name: r.volumeName})
 		if err != nil {
 			// fail if err is not from existing volume
@@ -208,6 +208,11 @@ func (r *DockerRegistry) EncodedLabeledAuth() string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`{"username":"%s","password":"%s"}`, r.username, r.password)))
 }
 
+//DockerHostname discovers the appropriate registry hostname based on:
+// * Any DOCKER_HOST=tcp://<host>, read host from the value
+// * Any host.docker.internal that resolves, use the IP
+// * Any exact IPs (<host IP>/32) in insecure-registry entries, assume that's the host's IP
+// * ... or, fallback to "localhost"
 func DockerHostname(t *testing.T) string {
 	dockerCli := DockerCli(t)
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -179,6 +179,7 @@ func DockerRmi(dockerCli dockercli.CommonAPIClient, repoNames ...string) error {
 	return err
 }
 
+//PushImage pushes an image to a registry, optionally using credentials from any set DOCKER_CONFIG
 func PushImage(dockerCli dockercli.CommonAPIClient, refStr string) error {
 	ref, err := name.ParseReference(refStr, name.WeakValidation)
 	if err != nil {


### PR DESCRIPTION
This is useful for consumers of DockerRegistry helper, particularly lifecycle (maybe pack, whose [impl](https://github.com/buildpacks/pack/blob/main/testhelpers/registry.go#L182) this was based on and already supports this), when running test containers that access the separate registry container, listening on a published host port. Currently, this was only possible with `--network=host` which can't be used on Windows. This also lets a Unix workstation run tests against a remote Windows (or any arch/OS) daemon with `DOCKER_HOST=tcp://<daemon host>` set.

The test registry now has a `Host` field, whose value is autodetected from the host and which can be used in image refs that need to be written to it: ex: `registry.Host + ":" + registry.Port + "/image-name:tag"`.

The logic to detect the host IP:
  - Any exact IPs (`<host IP>/32`) in `insecure-registry` entries, assume that's the host's IP
  - ... or, fallback to "localhost"

This does not change the current behavior for imgutil when running on GHA, which has none of the above set so will use "localhost".

This also replaces `stefanscherer/registry-windows`, which had a bug where it would return sporadic 503s. This bug appears fixed in docker-distribution 2.7.1 but the image hasn't been update for over 2 years. This is replaced with a newly created [`micahyoung/registry`](https://github.com/micahyoung/registry-image) which hosts equivalent Windows & Linux AMD64/ARM images in a single manifest list and is updated automatically through GHA. This should make the test registry behave as consistently as possible, regardless of the OS/Arch. I'd be happy to donate this to `buildpacks` org or even move the `Dockerfile`s into this repo to be built on-demand.

Signed-off-by: Micah Young <ymicah@vmware.com>

(updated, remove extra registry host detection logic for simplicity)