### PR TITLE
Fix return value for 3 EOF errors

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -23,6 +23,8 @@ import (
 	"github.com/buildpacks/imgutil"
 )
 
+const maxRetries = 2
+
 type Image struct {
 	keychain   authn.Keychain
 	repoName   string
@@ -187,11 +189,11 @@ func newV1Image(keychain authn.Keychain, repoName string, platform imgutil.Platf
 	}
 
 	var image v1.Image
-	for i := 0; i < 3; i++ {
+	for i := 0; i < maxRetries+1; i++ {
 		time.Sleep(100 * time.Duration(i) * time.Millisecond) // wait if retrying
 		image, err = remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport), remote.WithPlatform(v1Platform))
 		if err != nil {
-			if err == io.EOF {
+			if err == io.EOF && i != maxRetries {
 				continue // retry if EOF
 			}
 			if transportErr, ok := err.(*transport.Error); ok && len(transportErr.Errors) > 0 {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -189,7 +189,7 @@ func newV1Image(keychain authn.Keychain, repoName string, platform imgutil.Platf
 	}
 
 	var image v1.Image
-	for i := 0; i < maxRetries+1; i++ {
+	for i := 0; i <= maxRetries; i++ {
 		time.Sleep(100 * time.Duration(i) * time.Millisecond) // wait if retrying
 		image, err = remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport), remote.WithPlatform(v1Platform))
 		if err != nil {


### PR DESCRIPTION
If we get 3 EOF errors, we want to return a nil image and an error.
In the former implementation, we would fall through to the return statement at the end of the function (nil error).

Thanks to @yaelharel for pointing this out.