### PR TITLE
Fixes registry helper on GHA

### DIFF
--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -155,12 +155,17 @@ func (r *DockerRegistry) Start(t *testing.T) {
 		AssertNil(t, err)
 
 		hostPortMap := inspect.NetworkSettings.Ports["5000/tcp"]
-		if len(hostPortMap) == 1 {
-			r.Port = hostPortMap[0].HostPort
-			break
+		for _, hostPortEntry := range hostPortMap {
+			if hostPortEntry.HostIP == "0.0.0.0" {
+				r.Port = hostPortEntry.HostPort
+				break
+			}
 		}
 
 		time.Sleep(500 * time.Millisecond)
+	}
+	if r.Port == "" {
+		t.Fatal("docker returned no host-port for registry")
 	}
 
 	var authHeaders map[string]string


### PR DESCRIPTION
It seems with Docker 20.10.6 ([release notes](https://docs.docker.com/engine/release-notes/#20106)), multiple host port mappings are now returned for a single container port (one host mapping for IPv4, a second for IPv6):

Printf of `ContainerInspect().NetworkSettings.Ports["5000/tcp"]`:
```
[]nat.PortBinding{
  nat.PortBinding{
    HostIP:"0.0.0.0", HostPort:"49160"
  },
  nat.PortBinding{
    HostIP:"::", HostPort:"49160"}
  }
}
```
The previous implementation only looked for a single entry during the wait logic. I change it here to now loop through all mappings, choosing the IPv4 mapping (when IP is `0.0.0.0`), and returning it's port. If nothing is found, fail the test with a better error, to avoid apparent 10s timeout message from before.

Signed-off-by: Micah Young <ymicah@vmware.com>