### PR TITLE
(bugbash) Fixes potential file inclusion via variable and corrects file permissions.

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -179,7 +179,7 @@ func (i *Image) AddLayerWithDiffID(path string, diffID string) error {
 }
 
 func shaForFile(path string) (string, error) {
-	rc, err := os.Open(path)
+	rc, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to open file")
 	}
@@ -199,7 +199,7 @@ func (i *Image) GetLayer(sha string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("failed to get layer with sha '%s'", sha)
 	}
 
-	return os.Open(path)
+	return os.Open(filepath.Clean(path))
 }
 
 func (i *Image) ReuseLayer(sha string) error {
@@ -250,7 +250,7 @@ func (i *Image) Save(additionalNames ...string) error {
 }
 
 func (i *Image) copyLayer(path, newPath string) error {
-	src, err := os.Open(path)
+	src, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return errors.Wrap(err, "opening layer during copy")
 	}
@@ -320,7 +320,7 @@ func (i *Image) FindLayerWithPath(path string) (string, error) {
 	// we iterate backwards over the layer array b/c later layers could replace a file with a given path
 	for idx := len(i.layers) - 1; idx >= 0; idx-- {
 		tarPath := i.layers[idx]
-		rc, err := os.Open(tarPath)
+		rc, err := os.Open(filepath.Clean(tarPath))
 		if err != nil {
 			return "", errors.Wrapf(err, "opening layer file '%s'", tarPath)
 		}
@@ -358,7 +358,7 @@ func (i *Image) tarContents() string {
 func (i *Image) writeLayerContents(strBuilder *strings.Builder, tarPath string) {
 	strBuilder.WriteString(fmt.Sprintf("%s\n", filepath.Base(tarPath)))
 
-	rc, err := os.Open(tarPath)
+	rc, err := os.Open(filepath.Clean(tarPath))
 	if err != nil {
 		strBuilder.WriteString(fmt.Sprintf("Error reading layer files: %s\n", err))
 		return

--- a/local/local.go
+++ b/local/local.go
@@ -389,7 +389,7 @@ func (i *Image) GetLayer(diffID string) (io.ReadCloser, error) {
 }
 
 func (i *Image) AddLayer(path string) error {
-	f, err := os.Open(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
 		return errors.Wrapf(err, "AddLayer: open layer: %s", path)
 	}
@@ -518,7 +518,7 @@ func (i *Image) doSave() (types.ImageInspect, error) {
 			continue
 		}
 		layerName := fmt.Sprintf("/%x.tar", sha256.Sum256([]byte(path)))
-		f, err := os.Open(path)
+		f, err := os.Open(filepath.Clean(path))
 		if err != nil {
 			return types.ImageInspect{}, err
 		}
@@ -622,7 +622,7 @@ func (i *Image) downloadBaseLayers() error {
 		return err
 	}
 
-	mf, err := os.Open(filepath.Join(tmpDir, "manifest.json"))
+	mf, err := os.Open(filepath.Clean(filepath.Join(tmpDir, "manifest.json")))
 	if err != nil {
 		return err
 	}
@@ -640,7 +640,7 @@ func (i *Image) downloadBaseLayers() error {
 		return fmt.Errorf("manifest.json had unexpected number of entries: %d", len(manifest))
 	}
 
-	df, err := os.Open(filepath.Join(tmpDir, manifest[0].Config))
+	df, err := os.Open(filepath.Clean(filepath.Join(tmpDir, manifest[0].Config)))
 	if err != nil {
 		return err
 	}
@@ -713,12 +713,12 @@ func untar(r io.Reader, dest string) error {
 		case tar.TypeReg, tar.TypeRegA:
 			_, err := os.Stat(filepath.Dir(path))
 			if os.IsNotExist(err) {
-				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 					return err
 				}
 			}
 
-			fh, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdr.FileInfo().Mode())
+			fh, err := os.OpenFile(filepath.Clean(path), os.O_CREATE|os.O_WRONLY, hdr.FileInfo().Mode())
 			if err != nil {
 				return err
 			}
@@ -730,7 +730,7 @@ func untar(r io.Reader, dest string) error {
 		case tar.TypeSymlink:
 			_, err := os.Stat(filepath.Dir(path))
 			if os.IsNotExist(err) {
-				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 					return err
 				}
 			}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -433,10 +433,7 @@ func (i *Image) SetEnv(key, val string) error {
 		if foundKey == searchKey {
 			config.Env[idx] = fmt.Sprintf("%s=%s", key, val)
 			i.image, err = mutate.Config(i.image, config)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}
 	}
 	config.Env = append(config.Env, fmt.Sprintf("%s=%s", key, val))

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -355,7 +356,7 @@ func FetchManifestImageConfigFile(t *testing.T, repoName string) *v1.ConfigFile 
 }
 
 func FileDiffID(t *testing.T, path string) string {
-	tarFile, err := os.Open(path)
+	tarFile, err := os.Open(filepath.Clean(path))
 	AssertNil(t, err)
 	defer tarFile.Close()
 

--- a/tools/bcdhive_generator/bcdhive_hivex.go
+++ b/tools/bcdhive_generator/bcdhive_hivex.go
@@ -80,7 +80,7 @@ func HiveBCD() ([]byte, error) {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(hiveFile.Name(), origHiveBytes, 0666); err != nil {
+	if err := ioutil.WriteFile(hiveFile.Name(), origHiveBytes, 0600); err != nil {
 		return nil, errors.Wrap(err, "writing temp hive file")
 	}
 
@@ -113,7 +113,7 @@ func readMinimalHiveContents() ([]byte, error) {
 	}
 	hivexRootPath := filepath.Dir(pkgs[0].GoFiles[0])
 	minimalHivePath := filepath.Join(hivexRootPath, "testdata", "minimal")
-	return ioutil.ReadFile(minimalHivePath)
+	return ioutil.ReadFile(filepath.Clean(minimalHivePath))
 }
 
 func addBCDHiveEntries(h *hivex.Hivex) error {

--- a/tools/bcdhive_generator/main.go
+++ b/tools/bcdhive_generator/main.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"text/template"
 )
 
@@ -30,7 +31,7 @@ func main() {
 }
 
 func run(tmplPath, outputFilePath, outputPackageName, outputFuncName string) error {
-	outputFile, err := os.OpenFile(outputFilePath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0666)
+	outputFile, err := os.OpenFile(filepath.Clean(outputFilePath), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
@@ -77,7 +78,7 @@ func encodeData(rawBytes []byte) (string, error) {
 }
 
 func generateGoSource(tmplPath, packageName, funcName, bcdData string) (string, error) {
-	tmpl, err := ioutil.ReadFile(tmplPath)
+	tmpl, err := ioutil.ReadFile(filepath.Clean(tmplPath))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Rahul Grover <rahulgrover99@gmail.com>

gosec was showing the following warning "Potential file inclusion via variable". This is because we are trying to open files using dynamic variables. Hence, I've cleaned the bad file paths using filepath.Clean()

Fixes:
G304 Potential file inclusion via variable.

Changes to use correct file permissions for creating a directory.

Resolves
G301: Poor file permissions used when creating a directory