### PR TITLE
Do not check error returned by i.copyLayer

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -221,10 +221,7 @@ func (i *Image) Save(additionalNames ...string) error {
 
 	for sha, path := range i.layersMap {
 		newPath := filepath.Join(i.layerDir, filepath.Base(path))
-		err = i.copyLayer(path, newPath)
-		if err != nil {
-			return err
-		}
+		i.copyLayer(path, newPath) // errcheck ignore
 		i.layersMap[sha] = newPath
 	}
 


### PR DESCRIPTION
This allows the lifecycle to provide an empty path when calling `AddPreviousLayer` on the fake.

Signed-off-by: Natalie Arellano <narellano@vmware.com>