### PR TITLE
Adding a custom http handler for read/write access validation

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -356,7 +356,7 @@ func (i *Image) CheckReadWriteAccess() bool {
 	if err != nil {
 		return false
 	}
-	return remote.CheckPushPermission(ref, i.keychain, http.DefaultTransport) == nil
+	return i.CheckReadAccess() && remote.CheckPushPermission(ref, i.keychain, http.DefaultTransport) == nil
 }
 
 func (i *Image) CheckReadAccess() bool {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -23,10 +23,10 @@ import (
 var dockerRegistry, readonlyDockerRegistry, customRegistry *h.DockerRegistry
 
 const (
-	readWriteImage      = "image-readable-writable"
-	readNoWriteImage    = "image-readable"
-	noReadWriteImage    = "image-writable"
-	noReadNorWriteImage = "image-no-readable-no-writable"
+	readWriteImage = "image-readable-writable"
+	onlyReadImage  = "image-readable"
+	onlyWriteImage = "image-writable"
+	noAccessImage  = "noAccessImage"
 )
 
 func newTestImageName(providedPrefix ...string) string {
@@ -60,9 +60,9 @@ func TestRemote(t *testing.T) {
 
 	var customPrivileges = make(map[string]h.ImagePrivileges)
 	customPrivileges[readWriteImage] = h.NewImagePrivileges(readWriteImage)
-	customPrivileges[readNoWriteImage] = h.NewImagePrivileges(readNoWriteImage)
-	customPrivileges[noReadWriteImage] = h.NewImagePrivileges(noReadWriteImage)
-	customPrivileges[noReadNorWriteImage] = h.NewImagePrivileges("")
+	customPrivileges[onlyReadImage] = h.NewImagePrivileges(onlyReadImage)
+	customPrivileges[onlyWriteImage] = h.NewImagePrivileges(onlyWriteImage)
+	customPrivileges[noAccessImage] = h.NewImagePrivileges(noAccessImage)
 	customRegistry = h.NewDockerRegistry(h.WithAuth(customDockerConfigDir), h.WithSharedHandler(sharedRegistryHandler),
 		h.WithCustomPrivileges(customPrivileges))
 
@@ -1570,7 +1570,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
 			})
 
-			when("image has read/write access", func() {
+			when("image has read and write access", func() {
 				it("returns true", func() {
 					image, err := remote.NewImage(customRegistry.RepoName(readWriteImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
@@ -1580,7 +1580,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has read access but no write access", func() {
 				it("returns true", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(readNoWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(onlyReadImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadAccess(), true)
 				})
@@ -1588,7 +1588,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image doesn't have read access but has write access", func() {
 				it("returns false", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(noReadWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(onlyWriteImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadAccess(), false)
 				})
@@ -1596,7 +1596,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image doesn't have read nor write access", func() {
 				it("returns false", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(noReadNorWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(noAccessImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadAccess(), false)
 				})
@@ -1668,7 +1668,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
 			})
 
-			when("image has read/write access", func() {
+			when("image has read and write access", func() {
 				it("returns true", func() {
 					image, err := remote.NewImage(customRegistry.RepoName(readWriteImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
@@ -1678,7 +1678,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has read access but no write access", func() {
 				it("returns false", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(readNoWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(onlyReadImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadWriteAccess(), false)
 				})
@@ -1686,7 +1686,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image doesn't have read access but has write access", func() {
 				it("returns true", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(noReadWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(onlyWriteImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadWriteAccess(), false)
 				})
@@ -1694,7 +1694,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			when("image doesn't have read nor write access", func() {
 				it("returns false", func() {
-					image, err := remote.NewImage(customRegistry.RepoName(noReadNorWriteImage), authn.DefaultKeychain)
+					image, err := remote.NewImage(customRegistry.RepoName(noAccessImage), authn.DefaultKeychain)
 					h.AssertNil(t, err)
 					h.AssertEq(t, image.CheckReadWriteAccess(), false)
 				})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -20,7 +20,14 @@ import (
 	h "github.com/buildpacks/imgutil/testhelpers"
 )
 
-var dockerRegistry, readonlyDockerRegistry *h.DockerRegistry
+var dockerRegistry, readonlyDockerRegistry, customRegistry *h.DockerRegistry
+
+const (
+	readWriteImage      = "image-readable-writable"
+	readNoWriteImage    = "image-readable"
+	noReadWriteImage    = "image-writable"
+	noReadNorWriteImage = "image-no-readable-no-writable"
+)
 
 func newTestImageName(providedPrefix ...string) string {
 	prefix := "pack-image-test"
@@ -46,6 +53,20 @@ func TestRemote(t *testing.T) {
 	readonlyDockerRegistry = h.NewDockerRegistry(h.WithSharedHandler(sharedRegistryHandler))
 	readonlyDockerRegistry.Start(t)
 	defer readonlyDockerRegistry.Stop(t)
+
+	customDockerConfigDir, err := ioutil.TempDir("", "test.docker.config.custom.dir")
+	h.AssertNil(t, err)
+	defer os.RemoveAll(customDockerConfigDir)
+
+	var customPrivileges = make(map[string]h.ImagePrivileges)
+	customPrivileges[readWriteImage] = h.NewImagePrivileges(readWriteImage)
+	customPrivileges[readNoWriteImage] = h.NewImagePrivileges(readNoWriteImage)
+	customPrivileges[noReadWriteImage] = h.NewImagePrivileges(noReadWriteImage)
+	customPrivileges[noReadNorWriteImage] = h.NewImagePrivileges("")
+	customRegistry = h.NewDockerRegistry(h.WithAuth(customDockerConfigDir), h.WithSharedHandler(sharedRegistryHandler),
+		h.WithCustomPrivileges(customPrivileges))
+
+	customRegistry.Start(t)
 
 	os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
 	defer os.Unsetenv("DOCKER_CONFIG")
@@ -1539,6 +1560,48 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, image.CheckReadAccess(), false)
 			})
 		})
+
+		when("using custom handler", func() {
+			it.Before(func() {
+				os.Setenv("DOCKER_CONFIG", customRegistry.DockerDirectory)
+			})
+
+			it.After(func() {
+				os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
+			})
+
+			when("image has read/write access", func() {
+				it("returns true", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(readWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadAccess(), true)
+				})
+			})
+
+			when("image has read access but no write access", func() {
+				it("returns true", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(readNoWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadAccess(), true)
+				})
+			})
+
+			when("image doesn't have read access but has write access", func() {
+				it("returns false", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(noReadWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadAccess(), false)
+				})
+			})
+
+			when("image doesn't have read nor write access", func() {
+				it("returns false", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(noReadNorWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadAccess(), false)
+				})
+			})
+		})
 	})
 
 	when("#CheckReadWriteAccess", func() {
@@ -1593,6 +1656,48 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				image, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 				h.AssertEq(t, image.CheckReadWriteAccess(), false)
+			})
+		})
+
+		when("using custom handler", func() {
+			it.Before(func() {
+				os.Setenv("DOCKER_CONFIG", customRegistry.DockerDirectory)
+			})
+
+			it.After(func() {
+				os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)
+			})
+
+			when("image has read/write access", func() {
+				it("returns true", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(readWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadWriteAccess(), true)
+				})
+			})
+
+			when("image has read access but no write access", func() {
+				it("returns false", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(readNoWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadWriteAccess(), false)
+				})
+			})
+
+			when("image doesn't have read access but has write access", func() {
+				it("returns true", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(noReadWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadWriteAccess(), false)
+				})
+			})
+
+			when("image doesn't have read nor write access", func() {
+				it("returns false", func() {
+					image, err := remote.NewImage(customRegistry.RepoName(noReadNorWriteImage), authn.DefaultKeychain)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.CheckReadWriteAccess(), false)
+				})
 			})
 		})
 	})

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -108,7 +108,7 @@ func Custom(handler http.Handler, permissions map[string]ImagePrivileges) http.H
 				}
 			} else {
 				if !permission.writable {
-					// write request was arrived while read permission isn't allowed
+					// write request was arrived while write permission isn't allowed
 					w.WriteHeader(401)
 					_, _ = w.Write([]byte("Unauthorized.\n"))
 					return

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -11,30 +11,45 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/registry"
 )
 
 type DockerRegistry struct {
-	Host            string
-	Port            string
-	Name            string
-	server          *httptest.Server
-	DockerDirectory string
-	username        string
-	password        string
-	regHandler      http.Handler
-	authnHandler    http.Handler
+	Host             string
+	Port             string
+	Name             string
+	server           *httptest.Server
+	DockerDirectory  string
+	username         string
+	password         string
+	regHandler       http.Handler
+	authnHandler     http.Handler
+	customHandler    http.Handler
+	customPrivileges map[string]ImagePrivileges
 }
 
 type RegistryOption func(registry *DockerRegistry)
+
+type ImagePrivileges struct {
+	Readable  bool
+	Writeable bool
+}
 
 //WithSharedHandler allows two instances to share the same data by re-using the registry handler.
 //Use an authenticated registry to write to a read-only unauthenticated registry.
 func WithSharedHandler(handler http.Handler) RegistryOption {
 	return func(registry *DockerRegistry) {
 		registry.regHandler = handler
+	}
+}
+
+//WithCustomPrivileges allows to execute some customer read/write access validations based on the image name
+func WithCustomPrivileges(permissions map[string]ImagePrivileges) RegistryOption {
+	return func(registry *DockerRegistry) {
+		registry.customPrivileges = permissions
 	}
 }
 
@@ -88,6 +103,36 @@ func ReadOnly(handler http.Handler) http.Handler {
 	})
 }
 
+func Custom(handler http.Handler, permissions map[string]ImagePrivileges) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "blobs") ||
+			strings.Contains(r.URL.Path, "manifests") ||
+			strings.Contains(r.URL.Path, "tags") {
+			elems := strings.Split(r.URL.Path, "/")
+			elems = elems[1:]
+			name := elems[len(elems)-1]
+			if r.Method == "GET" || r.Method == "HEAD" {
+				if permission, ok := permissions[name]; ok {
+					if !permission.Readable {
+						w.WriteHeader(401)
+						_, _ = w.Write([]byte("Unauthorized.\n"))
+						return
+					}
+				}
+			} else {
+				if permission, ok := permissions[name]; ok {
+					if !permission.Writeable {
+						w.WriteHeader(401)
+						_, _ = w.Write([]byte("Unauthorized.\n"))
+						return
+					}
+				}
+			}
+		}
+		handler.ServeHTTP(w, r)
+	})
+}
+
 func (r *DockerRegistry) Start(t *testing.T) {
 	t.Helper()
 
@@ -103,6 +148,9 @@ func (r *DockerRegistry) Start(t *testing.T) {
 	// wrap registry handler with authentication handler, defaulting to read-only
 	r.authnHandler = ReadOnly(r.regHandler)
 	if r.username != "" {
+		if r.customHandler != nil && r.customPrivileges != nil {
+			r.regHandler = Custom(r.regHandler, r.customPrivileges)
+		}
 		r.authnHandler = BasicAuth(r.regHandler, r.username, r.password, "registry")
 	}
 

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -26,7 +26,7 @@ type DockerRegistry struct {
 	password         string
 	regHandler       http.Handler
 	authnHandler     http.Handler
-	customPrivileges map[string]ImagePrivileges
+	customPrivileges map[string]ImagePrivileges // map from an imageNames to its permissions
 }
 
 type RegistryOption func(registry *DockerRegistry)

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -26,7 +26,7 @@ type DockerRegistry struct {
 	password         string
 	regHandler       http.Handler
 	authnHandler     http.Handler
-	customPrivileges map[string]ImagePrivileges // map from an imageNames to its permissions
+	customPrivileges map[string]ImagePrivileges // map from an imageName to its permissions
 }
 
 type RegistryOption func(registry *DockerRegistry)
@@ -101,12 +101,14 @@ func Custom(handler http.Handler, permissions map[string]ImagePrivileges) http.H
 		if permission, ok := permissions[extractImageName(r.URL.Path)]; ok {
 			if r.Method == "GET" || r.Method == "HEAD" {
 				if !permission.readable {
+					// read request was arrived while read permission isn't allowed
 					w.WriteHeader(401)
 					_, _ = w.Write([]byte("Unauthorized.\n"))
 					return
 				}
 			} else {
 				if !permission.writable {
+					// write request was arrived while read permission isn't allowed
 					w.WriteHeader(401)
 					_, _ = w.Write([]byte("Unauthorized.\n"))
 					return

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -26,7 +26,7 @@ type DockerRegistry struct {
 	password         string
 	regHandler       http.Handler
 	authnHandler     http.Handler
-	customPrivileges map[string]*ImagePrivileges
+	customPrivileges map[string]ImagePrivileges
 }
 
 type RegistryOption func(registry *DockerRegistry)
@@ -40,7 +40,7 @@ func WithSharedHandler(handler http.Handler) RegistryOption {
 }
 
 //WithCustomPrivileges allows to execute some customer read/write access validations based on the image name
-func WithCustomPrivileges(permissions map[string]*ImagePrivileges) RegistryOption {
+func WithCustomPrivileges(permissions map[string]ImagePrivileges) RegistryOption {
 	return func(registry *DockerRegistry) {
 		registry.customPrivileges = permissions
 	}
@@ -96,7 +96,7 @@ func ReadOnly(handler http.Handler) http.Handler {
 	})
 }
 
-func Custom(handler http.Handler, permissions map[string]*ImagePrivileges) http.Handler {
+func Custom(handler http.Handler, permissions map[string]ImagePrivileges) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if permission, ok := permissions[extractImageName(r.URL.Path)]; ok {
 			if r.Method == "GET" || r.Method == "HEAD" {
@@ -106,7 +106,7 @@ func Custom(handler http.Handler, permissions map[string]*ImagePrivileges) http.
 					return
 				}
 			} else {
-				if !permission.writeable {
+				if !permission.writable {
 					w.WriteHeader(401)
 					_, _ = w.Write([]byte("Unauthorized.\n"))
 					return

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -8,19 +8,14 @@ import (
 var urlRegex = regexp.MustCompile(`v2\/(.*)\/(?:blobs|manifests|tags)`)
 
 type ImagePrivileges struct {
-	readable  bool
-	writeable bool
+	readable bool
+	writable bool
 }
 
-func NewImagePrivileges(imageName string) *ImagePrivileges {
-	var isReadable, isWriteable bool
-	if strings.Contains(imageName, "readable") {
-		isReadable = true
-	}
-	if strings.Contains(imageName, "writable") {
-		isWriteable = true
-	}
-	return &ImagePrivileges{readable: isReadable, writeable: isWriteable}
+func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
+	priv.readable = strings.Contains(imageName, "readable")
+	priv.writable = strings.Contains(imageName, "writable")
+	return
 }
 
 func extractImageName(path string) string {

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -1,0 +1,36 @@
+package testhelpers
+
+import (
+	"regexp"
+	"strings"
+)
+
+var urlRegex = regexp.MustCompile(`v2\/(.*)\/(?:blobs|manifests|tags)`)
+
+type ImagePrivileges struct {
+	readable  bool
+	writeable bool
+}
+
+func NewImagePrivileges(imageName string) *ImagePrivileges {
+	isReadable := false
+	isWriteable := false
+	if strings.Contains(imageName, "readable") {
+		isReadable = true
+	}
+	if strings.Contains(imageName, "writable") {
+		isWriteable = true
+	}
+	return &ImagePrivileges{readable: isReadable, writeable: isWriteable}
+}
+
+func extractImageName(path string) string {
+	var name string
+	if strings.Contains(path, "blobs") ||
+		strings.Contains(path, "manifests") ||
+		strings.Contains(path, "tags") {
+		matches := urlRegex.FindStringSubmatch(path)
+		name = matches[1]
+	}
+	return name
+}

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -18,6 +18,11 @@ func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
 	return
 }
 
+// Based of the registry API specification https://docs.docker.com/registry/spec/api/
+// This method returns the image name for path value that matches requests to blobs, manifests or tags
+// For examples:
+// extractImageName("v2/foo.bar/blobs/") returns "foo.bar"
+// extractImageName("v2/foo/bar/manifests/") returns "foo/bar"
 func extractImageName(path string) string {
 	var name string
 	if strings.Contains(path, "blobs") ||

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -13,8 +13,7 @@ type ImagePrivileges struct {
 }
 
 func NewImagePrivileges(imageName string) *ImagePrivileges {
-	isReadable := false
-	isWriteable := false
+	var isReadable, isWriteable bool
 	if strings.Contains(imageName, "readable") {
 		isReadable = true
 	}

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -12,6 +12,12 @@ type ImagePrivileges struct {
 	writable bool
 }
 
+// Creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
+// For examples:
+// NewImagePrivileges("") returns ImagePrivileges{readable: false, writable: false}
+// NewImagePrivileges("foo-readable") returns ImagePrivileges{readable: true, writable: false}
+// NewImagePrivileges("foo-writable") returns ImagePrivileges{readable: false, writable: true}
+// NewImagePrivileges("foo-writable-readable") returns ImagePrivileges{readable: true, writable: true}
 func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
 	priv.readable = strings.Contains(imageName, "readable")
 	priv.writable = strings.Contains(imageName, "writable")


### PR DESCRIPTION
Signed-off-by: Juan Bustamante <jbustamante@vmware.com>

## Summary

This PR is adding a custom HTTP handler to the docker registry to validate read/write access to some image name, these methods will be used to fix the issue [572 - validate registry credentials](https://github.com/buildpacks/lifecycle/issues/572) in the [lifecycle](https://github.com/buildpacks/lifecycle) repository

## Documentation

- Should this change be documented?
    - [x] No

## Related
Resolves #572 (in lifecycle)