### PR TITLE
Test helpers improvements

### DIFF
--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -59,10 +59,10 @@ func TestRemote(t *testing.T) {
 	defer os.RemoveAll(customDockerConfigDir)
 
 	var customPrivileges = make(map[string]h.ImagePrivileges)
-	customPrivileges[readWriteImage] = h.NewImagePrivileges(readWriteImage)
-	customPrivileges[onlyReadImage] = h.NewImagePrivileges(onlyReadImage)
-	customPrivileges[onlyWriteImage] = h.NewImagePrivileges(onlyWriteImage)
-	customPrivileges[noAccessImage] = h.NewImagePrivileges(noAccessImage)
+	customPrivileges[readWriteImage] = h.NewImagePrivileges(h.Readable, h.Writable)
+	customPrivileges[onlyReadImage] = h.NewImagePrivileges(h.Readable)
+	customPrivileges[onlyWriteImage] = h.NewImagePrivileges(h.Writable)
+	customPrivileges[noAccessImage] = h.NewImagePrivileges()
 	customRegistry = h.NewDockerRegistry(h.WithAuth(customDockerConfigDir), h.WithSharedHandler(sharedRegistryHandler),
 		h.WithCustomPrivileges(customPrivileges))
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -60,10 +60,10 @@ func TestRemote(t *testing.T) {
 	customRegistry = h.NewDockerRegistry(h.WithAuth(customDockerConfigDir), h.WithSharedHandler(sharedRegistryHandler),
 		h.WithImagePrivileges())
 
-	customRegistry.MakeReadWrite(readWriteImage)
-	customRegistry.MakeReadOnly(readOnlyImage)
-	customRegistry.MakeWriteOnly(writeOnlyImage)
-	customRegistry.MakeInaccessible(inaccessibleImage)
+	customRegistry.SetReadWrite(readWriteImage)
+	customRegistry.SetReadOnly(readOnlyImage)
+	customRegistry.SetWriteOnly(writeOnlyImage)
+	customRegistry.SetInaccessible(inaccessibleImage)
 	customRegistry.Start(t)
 
 	os.Setenv("DOCKER_CONFIG", dockerRegistry.DockerDirectory)

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -200,7 +200,7 @@ func (r *DockerRegistry) EncodedLabeledAuth() string {
 }
 
 // Add stores the given key name with the provided ImagePrivileges. For example
-// Add("my-image", NewImagePrivileges("foo-writable-readable")) will save "my-image" as a
+// Add("my-image", NewImagePrivileges(Readable, Writable)) will save "my-image" as a
 // readable and writable image into the registry.
 // It must be called before Start to have any effect.
 func (r *DockerRegistry) Add(key string, privilege ImagePrivileges) {

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -84,14 +84,14 @@ func BasicAuth(handler http.Handler, username, password, realm string) http.Hand
 
 // ReadOnly wraps a handler, allowing only GET and HEAD requests, otherwise rejecting with a 405
 func ReadOnly(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if !isReadRequest(request) {
-			w.WriteHeader(405)
-			_, _ = w.Write([]byte("Method Not Allowed.\n"))
+			response.WriteHeader(405)
+			_, _ = response.Write([]byte("Method Not Allowed.\n"))
 			return
 		}
 
-		handler.ServeHTTP(w, request)
+		handler.ServeHTTP(response, request)
 	})
 }
 

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -107,7 +107,9 @@ func Custom(basicAuthHandler http.Handler, regHandler http.Handler, permissions 
 					return
 				}
 			} else {
-				if !permission.writable {
+				if permission.writable {
+					regHandler.ServeHTTP(w, r)
+				} else {
 					// write request was arrived while write permission isn't allowed
 					w.WriteHeader(401)
 					_, _ = w.Write([]byte("Unauthorized.\n"))
@@ -141,9 +143,9 @@ func (r *DockerRegistry) Start(t *testing.T) {
 	if r.username != "" {
 		if r.customPrivileges != nil {
 			// wrap registry handler with basic auth
-			r.authnHandler = BasicAuth(r.regHandler, r.username, r.password, "registry")
+			basicAuthHandler := BasicAuth(r.regHandler, r.username, r.password, "registry")
 			// wrap registry handler with custom handler
-			r.authnHandler = Custom(r.authnHandler, r.regHandler, r.customPrivileges)
+			r.authnHandler = Custom(basicAuthHandler, r.regHandler, r.customPrivileges)
 		} else {
 			// wrap registry handler basic auth
 			r.authnHandler = BasicAuth(r.regHandler, r.username, r.password, "registry")

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -68,7 +68,8 @@ func NewDockerRegistry(ops ...RegistryOption) *DockerRegistry {
 }
 
 // BasicAuth wraps a handler, allowing requests with matching username and password headers, otherwise rejecting with a 401
-// optPermissions is used to skip the authentication check if the image is readable.
+// optPermissions is used to skip the authentication check if the image has been
+// configured in the test setup to be always readable.
 func BasicAuth(handler http.Handler, username, password, realm string, optPermissions ...map[string]ImagePrivileges) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(optPermissions) > 0 && (r.Method == "GET" || r.Method == "HEAD") {
@@ -127,10 +128,10 @@ func Custom(handler http.Handler, permissions map[string]ImagePrivileges) http.H
 }
 
 // Start creates a docker registry following these rules:
-// - Shared handler will be use, otherwise a new one will be created
-// - by default the shared handler will be wrapped using a read only handler
+// - Shared handler will be used, otherwise a new one will be created
+// - By default the shared handler will be wrapped with a read only handler
 // - In case credentials are configured, the shared handler will be wrapped with a basic authentication handler and
-//   in any image privileges were set, then custom handler will be use to wrap the auth handler.
+//   if any image privileges were set, then the custom handler will be used to wrap the auth handler.
 func (r *DockerRegistry) Start(t *testing.T) {
 	t.Helper()
 
@@ -200,7 +201,8 @@ func (r *DockerRegistry) EncodedLabeledAuth() string {
 
 // Add stores the given key name with the provided ImagePrivileges. For example
 // Add("my-image", NewImagePrivileges("foo-writable-readable")) will save "my-image" as a
-// readable and writable image into the registry
+// readable and writable image into the registry.
+// It must be called before Start to have any effect.
 func (r *DockerRegistry) Add(key string, privilege ImagePrivileges) {
 	r.customPrivileges[key] = privilege
 }

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -12,7 +12,7 @@ type ImagePrivileges struct {
 	writable bool
 }
 
-// NewImagePrivileges Creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
+// NewImagePrivileges creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
 // For examples:
 // NewImagePrivileges("") returns ImagePrivileges{readable: false, writable: false}
 // NewImagePrivileges("foo-readable") returns ImagePrivileges{readable: true, writable: false}
@@ -24,11 +24,11 @@ func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
 	return
 }
 
-// extractImageName returns the image name for path value that matches requests to blobs, manifests or tags
+// extractImageName returns the image name from a path value that matches requests to blobs, manifests or tags
 // For examples:
 // extractImageName("v2/foo.bar/blobs/") returns "foo.bar"
 // extractImageName("v2/foo/bar/manifests/") returns "foo/bar"
-// Based of the registry API specification https://docs.docker.com/registry/spec/api/
+// Based on the Docker registry API specification: https://docs.docker.com/registry/spec/api/
 func extractImageName(path string) string {
 	var name string
 	if strings.Contains(path, "blobs") ||

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -26,7 +26,7 @@ const (
 // NewImagePrivileges(Readable) returns ImagePrivileges{readable: true, writable: false}
 // NewImagePrivileges(Writable) returns ImagePrivileges{readable: false, writable: true}
 // NewImagePrivileges(Readable, Writable) returns ImagePrivileges{readable: true, writable: true}
-func NewImagePrivileges(imageAccess ...ImageAccess) (ImagePrivileges) {
+func NewImagePrivileges(imageAccess ...ImageAccess) ImagePrivileges {
 	var image ImagePrivileges
 	for _, ia := range imageAccess {
 		switch ia {
@@ -35,7 +35,7 @@ func NewImagePrivileges(imageAccess ...ImageAccess) (ImagePrivileges) {
 		case Writable:
 			image.writable = true
 		default:
-			fmt.Errorf("NewImagePrivileges doesn't recognize value '%d' as a valid image access value", imageAccess)
+			fmt.Printf("NewImagePrivileges doesn't recognize value '%d' as a valid image access value", imageAccess)
 		}
 	}
 	return image

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -12,7 +12,7 @@ type ImagePrivileges struct {
 	writable bool
 }
 
-// Creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
+// NewImagePrivileges Creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
 // For examples:
 // NewImagePrivileges("") returns ImagePrivileges{readable: false, writable: false}
 // NewImagePrivileges("foo-readable") returns ImagePrivileges{readable: true, writable: false}
@@ -24,11 +24,11 @@ func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
 	return
 }
 
-// Based of the registry API specification https://docs.docker.com/registry/spec/api/
-// This method returns the image name for path value that matches requests to blobs, manifests or tags
+// extractImageName returns the image name for path value that matches requests to blobs, manifests or tags
 // For examples:
 // extractImageName("v2/foo.bar/blobs/") returns "foo.bar"
 // extractImageName("v2/foo/bar/manifests/") returns "foo/bar"
+// Based of the registry API specification https://docs.docker.com/registry/spec/api/
 func extractImageName(path string) string {
 	var name string
 	if strings.Contains(path, "blobs") ||

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -1,6 +1,7 @@
 package testhelpers
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -25,16 +26,19 @@ const (
 // NewImagePrivileges(Readable) returns ImagePrivileges{readable: true, writable: false}
 // NewImagePrivileges(Writable) returns ImagePrivileges{readable: false, writable: true}
 // NewImagePrivileges(Readable, Writable) returns ImagePrivileges{readable: true, writable: true}
-func NewImagePrivileges(imageAccess ...ImageAccess) (priv ImagePrivileges) {
+func NewImagePrivileges(imageAccess ...ImageAccess) (ImagePrivileges) {
+	var image ImagePrivileges
 	for _, ia := range imageAccess {
 		switch ia {
 		case Readable:
-			priv.readable = true
+			image.readable = true
 		case Writable:
-			priv.writable = true
+			image.writable = true
+		default:
+			fmt.Errorf("NewImagePrivileges doesn't recognize value '%d' as a valid image access value", imageAccess)
 		}
 	}
-	return
+	return image
 }
 
 // extractImageName returns the image name from a path value that matches requests to blobs, manifests or tags

--- a/testhelpers/image_privileges.go
+++ b/testhelpers/image_privileges.go
@@ -12,15 +12,28 @@ type ImagePrivileges struct {
 	writable bool
 }
 
-// NewImagePrivileges creates a new ImagePrivileges, use "readable" or "writable" to set the properties accordingly.
+type ImageAccess int
+
+const (
+	Readable ImageAccess = iota
+	Writable
+)
+
+// NewImagePrivileges creates a new ImagePrivileges, use Readable or Writable to set the properties accordingly.
 // For examples:
-// NewImagePrivileges("") returns ImagePrivileges{readable: false, writable: false}
-// NewImagePrivileges("foo-readable") returns ImagePrivileges{readable: true, writable: false}
-// NewImagePrivileges("foo-writable") returns ImagePrivileges{readable: false, writable: true}
-// NewImagePrivileges("foo-writable-readable") returns ImagePrivileges{readable: true, writable: true}
-func NewImagePrivileges(imageName string) (priv ImagePrivileges) {
-	priv.readable = strings.Contains(imageName, "readable")
-	priv.writable = strings.Contains(imageName, "writable")
+// NewImagePrivileges() returns ImagePrivileges{readable: false, writable: false}
+// NewImagePrivileges(Readable) returns ImagePrivileges{readable: true, writable: false}
+// NewImagePrivileges(Writable) returns ImagePrivileges{readable: false, writable: true}
+// NewImagePrivileges(Readable, Writable) returns ImagePrivileges{readable: true, writable: true}
+func NewImagePrivileges(imageAccess ...ImageAccess) (priv ImagePrivileges) {
+	for _, ia := range imageAccess {
+		switch ia {
+		case Readable:
+			priv.readable = true
+		case Writable:
+			priv.writable = true
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
### References

- This Pull Request is created after [PR #125](https://github.com/buildpacks/imgutil/pull/125) was merged

### Context

The idea behind [PR #125](https://github.com/buildpacks/imgutil/pull/125) was to provide a structure to help us on testing the new validations in the lifecycle described in issue [#572](https://github.com/buildpacks/lifecycle/issues/572). At that point, some improvements were raised and the idea was to simply our docker registry implementation. This pull request is addressing those improvements.

### Description

- The PR exposes a new method `Add` to allow dynamically configure the `ImagePrivileges` in the registry, basically providing an option to include new mappings after the registry was created.
- The PR is also addressing one little problem that avoid us from using only one docker registry implementation to do our tests.

### Actual

Right now, if we need to simulate a read-only registry or a registry based on basic authentication, we need to create two instances similar  to the following image

<img width="488" alt="test-helpers-improvements-1" src="https://user-images.githubusercontent.com/1181799/127393730-dfce62f2-bb51-407c-98e1-32090c5c9f32.png">

Basically, if the registry is read-only no authentication check is made. After merging the [PR #125](https://github.com/buildpacks/imgutil/pull/125), we added a third behavior

![wrapping](https://user-images.githubusercontent.com/1181799/127393932-3a6a7ba0-96ff-4b48-abfb-5d1262aedb05.png)
 
As we can see, the problem that avoid us from using the custom registry to implement both behaviors (read-only and basic authentication) is that for the case of read-only we are actually running credential validation!

### After

The PR is implementing the following behavior 

<img width="609" alt="registry-3" src="https://user-images.githubusercontent.com/1181799/129116055-fb78929b-b687-4080-a093-35344e207850.png">

We are improving the Custom logic to handle the scenarios:
 * The image is readable
 * The image is writable 
 * Or both
 In this way, we are going to be able to simplify the tests in the lifecycle by removing the docker registry instances and using only one to handle all the test cases