### PR TITLE
Allow callers to pass a custom CreatedAt value

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -153,6 +153,11 @@ func (i *Image) SetCmd(v ...string) error {
 	return nil
 }
 
+func (i *Image) SetCreatedAt(t time.Time) error {
+	i.createdAt = t
+	return nil
+}
+
 func (i *Image) Env(k string) (string, error) {
 	return i.env[k], nil
 }

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1607,7 +1607,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("the WithCreatedAt option is used", func() {
-				it("zeroes times and client specific fields", func() {
+				it("uses the value for all times and client specific fields", func() {
 					expectedTime := time.Date(2022, 1, 5, 5, 5, 5, 0, time.UTC)
 					img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(runnableBaseImageName),
 						local.WithCreatedAt(expectedTime),

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1606,6 +1606,38 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				}
 			})
 
+			when("the WithCreatedAt option is used", func() {
+				it("zeroes times and client specific fields", func() {
+					expectedTime := time.Date(2022, 1, 5, 5, 5, 5, 0, time.UTC)
+					img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(runnableBaseImageName),
+						local.WithCreatedAt(expectedTime),
+					)
+					h.AssertNil(t, err)
+
+					err = img.SetLabel("mykey", "newValue")
+					h.AssertNil(t, err)
+
+					err = img.AddLayer(tarPath)
+					h.AssertNil(t, err)
+
+					h.AssertNil(t, img.Save())
+
+					inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, inspect.Created, expectedTime.Format(time.RFC3339))
+					h.AssertEq(t, inspect.Container, "")
+					h.AssertEq(t, inspect.DockerVersion, "")
+
+					history, err := dockerClient.ImageHistory(context.TODO(), repoName)
+					h.AssertNil(t, err)
+					h.AssertEq(t, len(history), len(inspect.RootFS.Layers))
+					for i := range inspect.RootFS.Layers {
+						h.AssertEq(t, history[i].Created, expectedTime.Unix())
+					}
+				})
+			})
+
 			when("additional names are provided", func() {
 				var (
 					additionalRepoNames = []string{


### PR DESCRIPTION
This will be used when resolving https://github.com/buildpacks/lifecycle/issues/809. The caller being able to adjust the value will allow us to read the value from different inputs if needed and won't tie imgutil to a specific env var.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>