### PR TITLE
Add `WorkingDir()` to return image working directory

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -313,8 +313,8 @@ func (i *Image) ReusedLayers() []string {
 	return i.reusedLayers
 }
 
-func (i *Image) WorkingDir() string {
-	return i.workingDir
+func (i *Image) WorkingDir() (string, error) {
+	return i.workingDir, nil
 }
 
 func (i *Image) AddPreviousLayer(sha, path string) {

--- a/image.go
+++ b/image.go
@@ -41,6 +41,7 @@ type Image interface {
 	SetLabel(string, string) error
 	RemoveLabel(string) error
 	Env(key string) (string, error)
+	WorkingDir() (string, error)
 	Entrypoint() ([]string, error)
 	SetEnv(string, string) error
 	SetEntrypoint(...string) error

--- a/local/local.go
+++ b/local/local.go
@@ -234,6 +234,10 @@ func (i *Image) Env(key string) (string, error) {
 	return "", nil
 }
 
+func (i *Image) WorkingDir() (string, error) {
+	return i.inspect.Config.WorkingDir, nil
+}
+
 func (i *Image) Entrypoint() ([]string, error) {
 	return i.inspect.Config.Entrypoint, nil
 }

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -551,6 +551,60 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#WorkingDir", func() {
+		when("image exists", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, existingImage.SetWorkingDir("/testWorkingDir"))
+				h.AssertNil(t, existingImage.Save())
+			})
+
+			it.After(func() {
+				h.AssertNil(t, h.DockerRmi(dockerClient, repoName))
+			})
+
+			it("returns the WorkingDir value", func() {
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, val, "/testWorkingDir")
+			})
+
+			it("returns empty string for missing WorkingDir", func() {
+				existingImage, err := local.NewImage(repoName, dockerClient)
+				h.AssertNil(t, err)
+				h.AssertNil(t, existingImage.Save())
+
+				img, err := local.NewImage(repoName, dockerClient, local.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+				var expected string
+				h.AssertEq(t, val, expected)
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns empty string", func() {
+				img, err := local.NewImage(newTestImageName(), dockerClient)
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+				var expected string
+				h.AssertEq(t, val, expected)
+			})
+		})
+	})
+
 	when("#Entrypoint", func() {
 		when("image exists", func() {
 			var repoName = newTestImageName()

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -305,6 +305,17 @@ func (i *Image) Env(key string) (string, error) {
 	return "", nil
 }
 
+func (i *Image) WorkingDir() (string, error) {
+	cfg, err := i.image.ConfigFile()
+	if err != nil {
+		return "", errors.Wrapf(err, "getting config file for image %q", i.repoName)
+	}
+	if cfg == nil {
+		return "", fmt.Errorf("missing config for image %q", i.repoName)
+	}
+	return cfg.Config.WorkingDir, nil
+}
+
 func (i *Image) Entrypoint() ([]string, error) {
 	cfg, err := i.image.ConfigFile()
 	if err != nil {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -522,6 +522,56 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#WorkingDir", func() {
+		when("image exists", func() {
+			var repoName = newTestImageName()
+
+			it.Before(func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				h.AssertNil(t, baseImage.SetWorkingDir("/testWorkingDir"))
+				h.AssertNil(t, baseImage.Save())
+			})
+
+			it("returns the WorkingDir value", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+
+				h.AssertEq(t, val, "/testWorkingDir")
+			})
+
+			it("returns empty string for a missing WorkingDir", func() {
+				baseImage, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+				h.AssertNil(t, baseImage.Save())
+
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain, remote.FromBaseImage(repoName))
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+				var expected string
+				h.AssertEq(t, val, expected)
+			})
+		})
+
+		when("image NOT exists", func() {
+			it("returns empty string", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				val, err := img.WorkingDir()
+				h.AssertNil(t, err)
+				var expected string
+				h.AssertEq(t, val, expected)
+			})
+		})
+	})
+
 	when("#Entrypoint", func() {
 		when("image exists with entrypoint", func() {
 			var repoName = newTestImageName()


### PR DESCRIPTION
https://github.com/buildpacks/pack/issues/1422 requires exposing `WorkingDir` from image inspect to process.
This PR adds relevant methods to do so.

- Add method to interface
- Add new tests for the function
- Update fakes/tests for the function