### PR TITLE
Add empty layer before saving on remote images

### DIFF
--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -520,6 +520,21 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
+
+		when("#AddEmptyLayerOnSave", func() {
+			it("an empty layer was added on save", func() {
+				image, err := remote.NewImage(
+					repoName,
+					authn.DefaultKeychain,
+					remote.WithPreviousImage("some-bad-repo-name"),
+					remote.AddEmptyLayerOnSave(),
+				)
+
+				h.AssertNil(t, err)
+				h.AssertNil(t, image.Save())
+				h.AssertEq(t, h.LayersSize(t, repoName), 1)
+			})
+		})
 	})
 
 	when("#WorkingDir", func() {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -343,6 +343,28 @@ func FileDiffID(t *testing.T, path string) string {
 	return diffID
 }
 
+func LayersSize(t *testing.T, repoName string) int {
+	t.Helper()
+
+	r, err := name.ParseReference(repoName, name.WeakValidation)
+	AssertNil(t, err)
+
+	auth, err := authn.DefaultKeychain.Resolve(r.Context().Registry)
+	AssertNil(t, err)
+
+	gImg, err := remote.Image(
+		r,
+		remote.WithTransport(http.DefaultTransport),
+		remote.WithAuth(auth),
+	)
+	AssertNil(t, err)
+
+	gLayers, err := gImg.Layers()
+	AssertNil(t, err)
+
+	return len(gLayers)
+}
+
 // RunnableBaseImage returns an image that can be used by a daemon of the same OS to create an container or run a command
 func RunnableBaseImage(os string) string {
 	if os == "windows" {


### PR DESCRIPTION
# Issue

When a build is configured to use a gcr.io cache-image but, the underlying build does not produce any cache layers the cache writing fails with:

```bash
failed to write image to the following tags: [gcr.io/some-repo/some-cache-image:latest: PUT https://gcr.io/v2/some-repo/some-cache-image/manifests/latest: MANIFEST_INVALID: Failed to parse manifest for request "/v2/cf-build-service-dev-219913/test/cache-image/manifests/latest": Manifest is missing required field "layers".]
```

# Description
The following fix adds an option to the **remote.Image** implementation to add an Empty Layer just before saving the image into the registry to avoid the error describe above.

Fixes https://github.com/buildpacks/lifecycle/issues/830

Signed-off-by: Juan Bustamante <jbustamante@vmware.com>