### PR TITLE
Introduce Image.SaveAs

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-containerregistry/pkg/name"
+	registryName "github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/imgutil"
@@ -218,6 +218,10 @@ func (i *Image) ReuseLayer(sha string) error {
 }
 
 func (i *Image) Save(additionalNames ...string) error {
+	return i.SaveAs(i.Name(), additionalNames...)
+}
+
+func (i *Image) SaveAs(name string, additionalNames ...string) error {
 	var err error
 	i.layerDir, err = ioutil.TempDir("", "fake-image")
 	if err != nil {
@@ -235,11 +239,11 @@ func (i *Image) Save(additionalNames ...string) error {
 		i.layers[l] = filepath.Join(i.layerDir, filepath.Base(layerPath))
 	}
 
-	allNames := append([]string{i.name}, additionalNames...)
+	allNames := append([]string{name}, additionalNames...)
 
 	var errs []imgutil.SaveDiagnostic
 	for _, n := range allNames {
-		_, err := name.ParseReference(n, name.WeakValidation)
+		_, err := registryName.ParseReference(n, registryName.WeakValidation)
 		if err != nil {
 			errs = append(errs, imgutil.SaveDiagnostic{ImageName: n, Cause: err})
 		} else {

--- a/image.go
+++ b/image.go
@@ -58,6 +58,8 @@ type Image interface {
 	TopLayer() (string, error)
 	// Save saves the image as `Name()` and any additional names provided to this method.
 	Save(additionalNames ...string) error
+	// SaveAs ignores the image `Name()` method and saves the image according to name & additional names provided to this method
+	SaveAs(name string, additionalNames ...string) error
 	// SaveFile saves the image as a docker archive and provides the filesystem location
 	SaveFile() (string, error)
 	// Found tells whether the image exists in the repository by `Name()`.

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -727,9 +727,13 @@ func findLayerWithSha(layers []v1.Layer, diffID string) (v1.Layer, error) {
 }
 
 func (i *Image) Save(additionalNames ...string) error {
+	return i.SaveAs(i.Name(), additionalNames...)
+}
+
+func (i *Image) SaveAs(name string, additionalNames ...string) error {
 	var err error
 
-	allNames := append([]string{i.repoName}, additionalNames...)
+	allNames := append([]string{name}, additionalNames...)
 
 	i.image, err = mutate.CreatedAt(i.image, v1.Time{Time: i.createdAt})
 	if err != nil {


### PR DESCRIPTION
This feature introduces `Image.SaveAs`. This allows saving an image with a name other than `Image.Name()`.

This feature is a partial requirement for the fulfillment of the [Lifecycle PR](https://github.com/buildpacks/lifecycle/pull/985) that resolves [Lifecycle Issue #983](https://github.com/buildpacks/lifecycle/issues/983).