### PR TITLE
Expose a method to parse an image reference into a local path

### DIFF
--- a/layout/util.go
+++ b/layout/util.go
@@ -1,0 +1,30 @@
+package layout
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"path/filepath"
+	"strings"
+)
+
+// ParseRefToPath parse the given image reference to local path directory following the rules:
+// An image reference refers to either a tag reference or digest reference.
+//   - A tag reference refers to an identifier of form <registry>/<repo>:<tag>
+//   - A digest reference refers to a content addressable identifier of form <registry>/<repo>@<algorithm>:<digest>
+//
+// WHEN the image reference points to a tag reference returns <registry>/<repo>/<tag>
+// WHEN the image reference points to a digest reference returns <registry>/<repo>/<algorithm>/<digest>
+func ParseRefToPath(imageRef string) (string, error) {
+	reference, err := name.ParseReference(imageRef, name.WeakValidation)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(reference.Context().RegistryStr(), reference.Context().RepositoryStr())
+	if strings.Contains(reference.Identifier(), ":") {
+		splitDigest := strings.Split(reference.Identifier(), ":")
+		path = filepath.Join(path, splitDigest[0], splitDigest[1])
+	} else {
+		path = filepath.Join(path, reference.Identifier())
+	}
+
+	return path, nil
+}

--- a/layout/util_test.go
+++ b/layout/util_test.go
@@ -1,0 +1,116 @@
+package layout_test
+
+import (
+	"fmt"
+	"github.com/buildpacks/imgutil/layout"
+	h "github.com/buildpacks/imgutil/testhelpers"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	defaultDockerRegistry = name.DefaultRegistry
+	defaultDockerRepo     = "library"
+)
+
+func Test(t *testing.T) {
+	spec.Run(t, "Utilities", test, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+type testCase struct {
+	description  string
+	focus        bool
+	imageRef     string
+	expectedPath string
+}
+
+func test(t *testing.T, when spec.G, it spec.S) {
+	when("All", func() {
+		for _, tc := range []testCase{
+			{
+				description:  "no registry, repo, tag or digest are provided",
+				imageRef:     "my-full-stack-run",
+				expectedPath: filepath.Join(defaultDockerRegistry, defaultDockerRepo, "my-full-stack-run", "latest"),
+			},
+			{
+				description:  "tag is provided but no registry or repo",
+				imageRef:     tag("my-full-stack-run", "bionic"),
+				expectedPath: filepath.Join(defaultDockerRegistry, defaultDockerRepo, "my-full-stack-run", "bionic"),
+			},
+			{
+				description:  "digest is provided but no registry or repo",
+				imageRef:     sha256("my-full-stack-run", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+				expectedPath: filepath.Join(defaultDockerRegistry, defaultDockerRepo, "my-full-stack-run", "sha256", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+			},
+			{
+				description:  "repo is provided but no registry tag or digest",
+				imageRef:     "cnb/my-full-stack-run",
+				expectedPath: filepath.Join(defaultDockerRegistry, "cnb", "my-full-stack-run", "latest"),
+			},
+			{
+				description:  "repo and tag are provided but no registry",
+				imageRef:     tag("cnb/my-full-stack-run", "bionic"),
+				expectedPath: filepath.Join(defaultDockerRegistry, "cnb", "my-full-stack-run", "bionic"),
+			},
+			{
+				description:  "repo and digest are provided but no registry",
+				imageRef:     sha256("cnb/my-full-stack-run", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+				expectedPath: filepath.Join(defaultDockerRegistry, "cnb", "my-full-stack-run", "sha256", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+			},
+			{
+				description:  "registry is provided but no repo tag or digest",
+				imageRef:     "my-registry.com/my-full-stack-run",
+				expectedPath: filepath.Join("my-registry.com", "my-full-stack-run", "latest"),
+			},
+			{
+				description:  "registry and tag are provided but no repo",
+				imageRef:     tag("my-registry.com/my-full-stack-run", "bionic"),
+				expectedPath: filepath.Join("my-registry.com", "my-full-stack-run", "bionic"),
+			},
+			{
+				description:  "registry and digest are provided but repo",
+				imageRef:     sha256("my-registry.com/my-full-stack-run", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+				expectedPath: filepath.Join("my-registry.com", "my-full-stack-run", "sha256", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+			},
+			{
+				description:  "registry and repo are provided but no tag or digest",
+				imageRef:     "my-registry.com/cnb/my-full-stack-run",
+				expectedPath: filepath.Join("my-registry.com", "cnb", "my-full-stack-run", "latest"),
+			},
+			{
+				description:  "registry repo and tag are provided",
+				imageRef:     tag("my-registry.com/cnb/my-full-stack-run", "bionic"),
+				expectedPath: filepath.Join("my-registry.com", "cnb", "my-full-stack-run", "bionic"),
+			},
+			{
+				description:  "registry repo and digest are provided",
+				imageRef:     sha256("my-registry.com/cnb/my-full-stack-run", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+				expectedPath: filepath.Join("my-registry.com", "cnb", "my-full-stack-run", "sha256", "f75f3d1a317fc82c793d567de94fc8df2bece37acd5f2bd364a0d91a0d1f3dab"),
+			},
+		} {
+			tc := tc
+			w := when
+			if tc.focus {
+				w = when.Focus
+			}
+			w(tc.description, func() {
+				it("parse image reference to local path", func() {
+					path, err := layout.ParseRefToPath(tc.imageRef)
+					h.AssertNil(t, err)
+					h.AssertEq(t, path, tc.expectedPath)
+				})
+			})
+		}
+	})
+}
+
+func tag(image, tag string) string {
+	return fmt.Sprintf("%s:%s", image, tag)
+}
+
+func sha256(image, digest string) string {
+	return fmt.Sprintf("%s@sha256:%s", image, digest)
+}


### PR DESCRIPTION
## Summary

This pull request exposes an utility method to parse an image reference into a local path using the following rules:

Considering an **image reference** refers to either a tag reference or digest reference. It has the following formats
- A tag reference refers to an identifier of form `<registry>/<repo>:<tag>`
- A digest reference refers to a content addressable identifier of form `<registry>/<repo>@<algorithm>:<digest>`

Expose a method like:

``` mermaid
classDiagram

class layout {
    ParseRefToPath(imageRef string) (string, error)
}
```

This method parses the given image reference to local path directory following the rules:
- WHEN the image reference points to a tag reference returns `<registry>/<repo>/<tag>`
- WHEN the image reference points to a digest reference returns `<registry>/<repo>/<algorithm>/<digest>`

Fixes #168 
Signed-off-by: Juan Bustamante <jbustamante@vmware.com>