### PR TITLE
Adding capability to write the org.opencontainers.image.ref.name to OCI layout image

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -291,6 +291,14 @@ func (i *Image) Found() bool {
 	return !i.deleted
 }
 
+func (i *Image) AnnotateRefName(refName string) error {
+	return nil
+}
+
+func (i *Image) GetAnnotateRefName() (string, error) {
+	return "", nil
+}
+
 // test methods
 
 func (i *Image) SetIdentifier(identifier imgutil.Identifier) {

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -33,6 +33,7 @@ func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 		os:            "linux",
 		osVersion:     "",
 		architecture:  "amd64",
+		annotations:   map[string]string{},
 	}
 }
 
@@ -58,6 +59,8 @@ type Image struct {
 	workingDir    string
 	savedNames    map[string]bool
 	manifestSize  int64
+	refName       string
+	annotations   map[string]string
 }
 
 func (i *Image) CreatedAt() (time.Time, error) {
@@ -240,6 +243,9 @@ func (i *Image) SaveAs(name string, additionalNames ...string) error {
 	}
 
 	allNames := append([]string{name}, additionalNames...)
+	if i.refName != "" {
+		i.annotations["org.opencontainers.image.ref.name"] = i.refName
+	}
 
 	var errs []imgutil.SaveDiagnostic
 	for _, n := range allNames {
@@ -292,11 +298,12 @@ func (i *Image) Found() bool {
 }
 
 func (i *Image) AnnotateRefName(refName string) error {
+	i.refName = refName
 	return nil
 }
 
 func (i *Image) GetAnnotateRefName() (string, error) {
-	return "", nil
+	return i.refName, nil
 }
 
 // test methods
@@ -440,4 +447,8 @@ func (i *Image) SetManifestSize(size int64) {
 
 func (i *Image) ManifestSize() (int64, error) {
 	return i.manifestSize, nil
+}
+
+func (i *Image) Annotations() map[string]string {
+	return i.annotations
 }

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -20,47 +20,47 @@ import (
 
 func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 	return &Image{
-		labels:        nil,
-		env:           map[string]string{},
-		topLayerSha:   topLayerSha,
-		identifier:    identifier,
-		name:          name,
-		cmd:           []string{"initialCMD"},
-		layersMap:     map[string]string{},
-		prevLayersMap: map[string]string{},
-		createdAt:     time.Now(),
-		savedNames:    map[string]bool{},
-		os:            "linux",
-		osVersion:     "",
-		architecture:  "amd64",
-		annotations:   map[string]string{},
+		labels:           nil,
+		env:              map[string]string{},
+		topLayerSha:      topLayerSha,
+		identifier:       identifier,
+		name:             name,
+		cmd:              []string{"initialCMD"},
+		layersMap:        map[string]string{},
+		prevLayersMap:    map[string]string{},
+		createdAt:        time.Now(),
+		savedNames:       map[string]bool{},
+		os:               "linux",
+		osVersion:        "",
+		architecture:     "amd64",
+		savedAnnotations: map[string]string{},
 	}
 }
 
 type Image struct {
-	deleted       bool
-	layers        []string
-	layersMap     map[string]string
-	prevLayersMap map[string]string
-	reusedLayers  []string
-	labels        map[string]string
-	env           map[string]string
-	topLayerSha   string
-	os            string
-	osVersion     string
-	architecture  string
-	identifier    imgutil.Identifier
-	name          string
-	entryPoint    []string
-	cmd           []string
-	base          string
-	createdAt     time.Time
-	layerDir      string
-	workingDir    string
-	savedNames    map[string]bool
-	manifestSize  int64
-	refName       string
-	annotations   map[string]string
+	deleted          bool
+	layers           []string
+	layersMap        map[string]string
+	prevLayersMap    map[string]string
+	reusedLayers     []string
+	labels           map[string]string
+	env              map[string]string
+	topLayerSha      string
+	os               string
+	osVersion        string
+	architecture     string
+	identifier       imgutil.Identifier
+	name             string
+	entryPoint       []string
+	cmd              []string
+	base             string
+	createdAt        time.Time
+	layerDir         string
+	workingDir       string
+	savedNames       map[string]bool
+	manifestSize     int64
+	refName          string
+	savedAnnotations map[string]string
 }
 
 func (i *Image) CreatedAt() (time.Time, error) {
@@ -244,7 +244,7 @@ func (i *Image) SaveAs(name string, additionalNames ...string) error {
 
 	allNames := append([]string{name}, additionalNames...)
 	if i.refName != "" {
-		i.annotations["org.opencontainers.image.ref.name"] = i.refName
+		i.savedAnnotations["org.opencontainers.image.ref.name"] = i.refName
 	}
 
 	var errs []imgutil.SaveDiagnostic
@@ -449,6 +449,6 @@ func (i *Image) ManifestSize() (int64, error) {
 	return i.manifestSize, nil
 }
 
-func (i *Image) Annotations() map[string]string {
-	return i.annotations
+func (i *Image) SavedAnnotations() map[string]string {
+	return i.savedAnnotations
 }

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -146,7 +146,7 @@ Layers
 
 			_ = image.Save()
 
-			annotations := image.Annotations()
+			annotations := image.SavedAnnotations()
 			refName, _ := image.GetAnnotateRefName()
 			h.AssertEq(t, annotations["org.opencontainers.image.ref.name"], refName)
 		})

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -136,6 +136,21 @@ Layers
 			})
 		})
 	})
+
+	when("#AnnotateRefName", func() {
+		var repoName = newRepoName()
+
+		it("adds org.opencontainers.image.ref.name annotation", func() {
+			image := fakes.NewImage(repoName, "", nil)
+			image.AnnotateRefName("my-tag")
+
+			_ = image.Save()
+
+			annotations := image.Annotations()
+			refName, _ := image.GetAnnotateRefName()
+			h.AssertEq(t, annotations["org.opencontainers.image.ref.name"], refName)
+		})
+	})
 }
 
 func createLayerTar(contents map[string]string) (string, error) {

--- a/image.go
+++ b/image.go
@@ -74,6 +74,9 @@ type Image interface {
 	Architecture() (string, error)
 	// ManifestSize returns the size of the manifest. If a manifest doesn't exist, it returns 0.
 	ManifestSize() (int64, error)
+	// AnnotateRefName set a value for the `org.opencontainers.image.ref.name` annotation
+	AnnotateRefName(refName string) error
+	GetAnnotateRefName() (string, error)
 }
 
 type Identifier fmt.Stringer

--- a/layout/identifier.go
+++ b/layout/identifier.go
@@ -1,28 +1,23 @@
 package layout
 
 import (
-	"crypto/sha256"
 	"fmt"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-type DigestIdentifier struct {
+type Identifier struct {
 	Digest string
+	Path   string
 }
 
-func newDigestIdentifier(configFile *v1.ConfigFile) (DigestIdentifier, error) {
-	return DigestIdentifier{
-		Digest: "sha256:" + asSha256(configFile),
+func newLayoutIdentifier(path string, hash v1.Hash) (Identifier, error) {
+	return Identifier{
+		Digest: hash.String(),
+		Path:   path,
 	}, nil
 }
 
-func (i DigestIdentifier) String() string {
-	return i.Digest
-}
-
-func asSha256(o interface{}) string {
-	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%v", o)))
-	return fmt.Sprintf("%x", h.Sum(nil))
+func (i Identifier) String() string {
+	return fmt.Sprintf("%s@%s", i.Path, i.Digest)
 }

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -744,7 +744,7 @@ func (i *Image) mutateImage(base v1.Image) {
 	}
 }
 
-// addOCILayer append the provided layer with media type application/vnd.oci.image.layer.v1.tar+gzip
+// addOCILayer appends the provided layer with media type application/vnd.oci.image.layer.v1.tar+gzip
 func (i *Image) addOCILayer(layer v1.Layer) error {
 	additions := layersAddendum([]v1.Layer{layer})
 	image, err := mutate.Append(i.Image, additions...)
@@ -776,7 +776,7 @@ func validMediaTypes(manifest *v1.Manifest) bool {
 
 // overridesMediaType will create a new v1.Image from the provided base image, but replacing
 // manifest media type, config media type and layers media type by the ones defined by the OCI spec
-func overridesMediaType(base v1.Image) v1.Image {
+func overrideMediaTypes(base v1.Image) v1.Image {
 	config, _ := base.ConfigFile()
 	config.RootFS.DiffIDs = make([]v1.Hash, 0)
 

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -748,7 +748,7 @@ func (i *Image) mutateImage(base v1.Image) {
 		}
 	} else {
 		// images has docker media types, we need to override them
-		newBaseImage := overridesMediaType(base)
+		newBaseImage := overrideMediaTypes(base)
 		i.Image = &Image{
 			Image: newBaseImage,
 		}

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -565,6 +565,7 @@ func (i *Image) SaveAs(name string, additionalNames ...string) error {
 }
 
 func (i *Image) SaveFile() (string, error) {
+	// TODO issue https://github.com/buildpacks/imgutil/issues/170
 	return "", errors.New("not yet implemented")
 }
 

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/buildpacks/imgutil"
@@ -81,6 +83,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				arch, err := img.Architecture()
 				h.AssertNil(t, err)
 				h.AssertEq(t, arch, "amd64")
+
+				h.AssertOCIMediaTypes(t, img)
 			})
 		})
 
@@ -96,6 +100,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
+				h.AssertOCIMediaTypes(t, img)
 
 				arch, err := img.Architecture()
 				h.AssertNil(t, err)
@@ -123,6 +128,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
+				h.AssertOCIMediaTypes(t, img)
 
 				arch, err := img.Architecture()
 				h.AssertNil(t, err)
@@ -150,6 +156,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 						img, err := layout.NewImage(imagePath, layout.FromBaseImage(testImage))
 						h.AssertNil(t, err)
+						h.AssertOCIMediaTypes(t, img)
 
 						os, err := img.OS()
 						h.AssertNil(t, err)
@@ -172,8 +179,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				when("base image does not exist", func() {
 					it("returns an empty image", func() {
 						img, err := layout.NewImage(imagePath, layout.FromBaseImage(nil))
-
 						h.AssertNil(t, err)
+						h.AssertOCIMediaTypes(t, img)
 
 						_, err = img.TopLayer()
 						h.AssertError(t, err, "has no layers")
@@ -189,6 +196,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := layout.NewImage(imagePath, layout.FromBaseImagePath(fullBaseImagePath))
 					h.AssertNil(t, err)
+					h.AssertOCIMediaTypes(t, img)
 
 					os, err := img.OS()
 					h.AssertNil(t, err)
@@ -214,6 +222,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := layout.NewImage(imagePath, layout.FromBaseImagePath(sparseBaseImagePath))
 					h.AssertNil(t, err)
+					h.AssertOCIMediaTypes(t, img)
 
 					os, err := img.OS()
 					h.AssertNil(t, err)
@@ -236,8 +245,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			when("base image does not exist", func() {
 				it("returns an empty image", func() {
 					img, err := layout.NewImage(imagePath, layout.FromBaseImagePath("some-bad-repo-name"))
-
 					h.AssertNil(t, err)
+					h.AssertOCIMediaTypes(t, img)
 
 					_, err = img.TopLayer()
 					h.AssertError(t, err, "has no layers")
@@ -267,8 +276,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					it("provides reusable layers", func() {
 						img, err := layout.NewImage(imagePath, layout.WithPreviousImage(previousImagePath))
-
 						h.AssertNil(t, err)
+						h.AssertOCIMediaTypes(t, img)
 
 						h.AssertNil(t, img.ReuseLayer(layerDiffID))
 					})
@@ -282,8 +291,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					it("provides reusable layers", func() {
 						img, err := layout.NewImage(imagePath, layout.WithPreviousImage(previousImagePath))
-
 						h.AssertNil(t, err)
+						h.AssertOCIMediaTypes(t, img)
 
 						h.AssertNil(t, img.ReuseLayer(layerDiffID))
 					})
@@ -810,9 +819,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						// expected blobs: manifest, config, reuse random layer
 						h.AssertBlobsLen(t, imagePath, 3)
 
-						size, err := image.ManifestSize()
+						mediaType, err := image.MediaType()
 						h.AssertNil(t, err)
-						h.AssertEq(t, size, int64(417))
+						h.AssertEq(t, mediaType, types.OCIManifestSchema1)
 					})
 				})
 			})
@@ -987,7 +996,6 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("Get layer from sparse base image", func() {
 				image, err := layout.NewImage(imagePath, layout.FromBaseImagePath(sparseBaseImagePath))
 				h.AssertNil(t, err)
-
 				// from testdata/layout/busybox-sparse/
 				diffID := "sha256:40cf597a9181e86497f4121c604f9f0ab208950a98ca21db883f26b0a548a2eb"
 				_, err = image.GetLayer(diffID)

--- a/layout/util.go
+++ b/layout/util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+const ImageRefNameKey = "org.opencontainers.image.ref.name"
+
 // ParseRefToPath parse the given image reference to local path directory following the rules:
 // An image reference refers to either a tag reference or digest reference.
 //   - A tag reference refers to an identifier of form <registry>/<repo>:<tag>
@@ -28,4 +30,14 @@ func ParseRefToPath(imageRef string) (string, error) {
 	}
 
 	return path, nil
+}
+
+// ImageRefAnnotation creates a map containing the key 'org.opencontainers.image.ref.name' with the provided value.
+func ImageRefAnnotation(imageRefName string) map[string]string {
+	if imageRefName == "" {
+		return nil
+	}
+	annotations := make(map[string]string, 1)
+	annotations[ImageRefNameKey] = imageRefName
+	return annotations
 }

--- a/layout/util.go
+++ b/layout/util.go
@@ -1,9 +1,10 @@
 package layout
 
 import (
-	"github.com/google/go-containerregistry/pkg/name"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 // ParseRefToPath parse the given image reference to local path directory following the rules:

--- a/layout/util_test.go
+++ b/layout/util_test.go
@@ -2,13 +2,15 @@ package layout_test
 
 import (
 	"fmt"
-	"github.com/buildpacks/imgutil/layout"
-	h "github.com/buildpacks/imgutil/testhelpers"
+	"path/filepath"
+	"testing"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-	"path/filepath"
-	"testing"
+
+	"github.com/buildpacks/imgutil/layout"
+	h "github.com/buildpacks/imgutil/testhelpers"
 )
 
 const (

--- a/local/local.go
+++ b/local/local.go
@@ -734,6 +734,14 @@ func (i *Image) ManifestSize() (int64, error) {
 	return 0, nil
 }
 
+func (i *Image) AnnotateRefName(refName string) error {
+	return nil
+}
+
+func (i *Image) GetAnnotateRefName() (string, error) {
+	return "", nil
+}
+
 // downloadBaseLayersOnce exports the base image from the daemon and populates layerPaths the first time it is called.
 // subsequent calls do nothing.
 func (i *Image) downloadBaseLayersOnce() error {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -865,10 +865,14 @@ func (i *Image) ManifestSize() (int64, error) {
 	return i.image.Size()
 }
 
-func (i *Image) AnnotateRefName(refName string) error { return nil }
+func (i *Image) AnnotateRefName(refName string) error {
+	// TODO issue https://github.com/buildpacks/imgutil/issues/178
+	return errors.New("not yet implemented")
+}
 
 func (i *Image) GetAnnotateRefName() (string, error) {
-	return "", nil
+	// TODO issue https://github.com/buildpacks/imgutil/issues/178
+	return "", errors.New("not yet implemented")
 }
 
 type subImage struct {

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -865,6 +865,12 @@ func (i *Image) ManifestSize() (int64, error) {
 	return i.image.Size()
 }
 
+func (i *Image) AnnotateRefName(refName string) error { return nil }
+
+func (i *Image) GetAnnotateRefName() (string, error) {
+	return "", nil
+}
+
 type subImage struct {
 	img       v1.Image
 	topDiffID string

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -480,6 +480,16 @@ func AssertPathExists(t *testing.T, path string) {
 	}
 }
 
+func AssertEqAnnotation(t *testing.T, manifest v1.Descriptor, key, value string) {
+	t.Helper()
+	AssertTrue(t, func() bool {
+		return len(manifest.Annotations) > 0
+	})
+	AssertTrue(t, func() bool {
+		return manifest.Annotations[key] == value
+	})
+}
+
 func ReadIndexManifest(t *testing.T, path string) *v1.IndexManifest {
 	indexPath := filepath.Join(path, "index.json")
 	AssertPathExists(t, filepath.Join(path, "oci-layout"))

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
 	"github.com/buildpacks/imgutil/layer"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -488,6 +490,23 @@ func AssertEqAnnotation(t *testing.T, manifest v1.Descriptor, key, value string)
 	AssertTrue(t, func() bool {
 		return manifest.Annotations[key] == value
 	})
+}
+
+func AssertOCIMediaTypes(t *testing.T, image v1.Image) {
+	t.Helper()
+
+	mediaType, err := image.MediaType()
+	AssertNil(t, err)
+	AssertEq(t, mediaType, types.OCIManifestSchema1)
+
+	manifest, err := image.Manifest()
+	AssertNil(t, err)
+	AssertNotEq(t, manifest.MediaType, "")
+	AssertEq(t, manifest.Config.MediaType, types.OCIConfigJSON)
+
+	for _, layer := range manifest.Layers {
+		AssertEq(t, layer.MediaType, types.OCILayer)
+	}
 }
 
 func ReadIndexManifest(t *testing.T, path string) *v1.IndexManifest {


### PR DESCRIPTION
## Description

This PR is adding the capability to the Layout image to add the `org.opencontainers.image.ref.name` annotation when the image is saved on disk.

Also, I included a modification to the `Image.Identifier()` method according to the discussion in this [thread](https://cloud-native.slack.com/archives/C0331B5QS02/p1674761476209019) 

### Additional change included

As I mentioned before, I've being trying to use [umoci](https://umo.ci/) to validate the output image generated by `layout` package. I noticed, that this tools only recognized OCI media types, like these:

```bash
Manifest - application/vnd.oci.image.manifest.v1+json
Config - application/vnd.oci.image.config.v1+json
Layers - application/vnd.oci.image.layer.v1.tar+gzip
```
Apparently, ggcr uses docker media types by default.

```bash
Manifest - application/vnd.docker.distribution.manifest.v2+json
Config - application/vnd.docker.container.image.v1+json
Layers - application/vnd.docker.image.rootfs.diff.tar.gzip
```
The original implementation was writing the image in OCI layout format using docker media types, as a consequence, if I tried to create a runtime bundle using  [umoci](https://umo.ci/) I was getting errors like:

```bash
 ⨯ create runtime bundle: unpack rootfs: unpack rootfs: layer 
sha256:72d9f18d70f395ff9bfae4d193077ccea3ca583e3da3dd66f5c84520c0100727: 
blob is not correct mediatype: application/vnd.docker.image.rootfs.diff.tar.gzip
```
 or something similar complaining about `application/vnd.docker.distribution.manifest.v2+json`

This PR also included some logic to workaround this, the idea is to validate if the given base image (path or v1.Image) has docker media types in such as case, I am trying to create a new image updating the media types. ggcr offers `mutate.MediaTypes` methods to do that BUT I had a lot of troubles trying to change the Layers media types.

Fixes #174 
Signed-off-by: Juan Bustamante <jbustamante@vmware.com>