### PR TITLE
Expose method to parse a layout image identifier

### DIFF
--- a/layout/identifier.go
+++ b/layout/identifier.go
@@ -6,6 +6,8 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+const identifierDelim = "@"
+
 type Identifier struct {
 	Digest string
 	Path   string
@@ -19,5 +21,5 @@ func newLayoutIdentifier(path string, hash v1.Hash) (Identifier, error) {
 }
 
 func (i Identifier) String() string {
-	return fmt.Sprintf("%s@%s", i.Path, i.Digest)
+	return fmt.Sprintf("%s%s%s", i.Path, identifierDelim, i.Digest)
 }

--- a/layout/util.go
+++ b/layout/util.go
@@ -1,21 +1,24 @@
 package layout
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
 )
 
 const ImageRefNameKey = "org.opencontainers.image.ref.name"
 
 // ParseRefToPath parse the given image reference to local path directory following the rules:
 // An image reference refers to either a tag reference or digest reference.
-//   - A tag reference refers to an identifier of form <registry>/<repo>:<tag>
-//   - A digest reference refers to a content addressable identifier of form <registry>/<repo>@<algorithm>:<digest>
+//   - A tag reference refers to an identifier of form <registry>/<repo>/<image>:<tag>
+//   - A digest reference refers to a content addressable identifier of form <registry>/<repo>/<image>@<algorithm>:<digest>
 //
-// WHEN the image reference points to a tag reference returns <registry>/<repo>/<tag>
-// WHEN the image reference points to a digest reference returns <registry>/<repo>/<algorithm>/<digest>
+// WHEN the image reference points to a tag reference returns <registry>/<repo>/<image>/<tag>
+// WHEN the image reference points to a digest reference returns <registry>/<repo>/<image>/<algorithm>/<digest>
 func ParseRefToPath(imageRef string) (string, error) {
 	reference, err := name.ParseReference(imageRef, name.WeakValidation)
 	if err != nil {
@@ -30,6 +33,24 @@ func ParseRefToPath(imageRef string) (string, error) {
 	}
 
 	return path, nil
+}
+
+// ParseIdentifier parse the given identifier string into a layout.Identifier.
+// WHEN image.Identifier() method is called, it returns the layout identifier with the format [path]@[digest] this
+// method reconstruct a string reference in that format into a layout.Identifier
+func ParseIdentifier(identifier string) (Identifier, error) {
+	if strings.Contains(identifier, identifierDelim) {
+		referenceSplit := strings.Split(identifier, identifierDelim)
+		if len(referenceSplit) == 2 {
+			hash, err := v1.NewHash(referenceSplit[1])
+			if err != nil {
+				return Identifier{}, err
+			}
+			path := path.Clean(referenceSplit[0])
+			return newLayoutIdentifier(path, hash)
+		}
+	}
+	return Identifier{}, errors.Errorf("identifier %s does not have the format '[path]%s[digest]'", identifier, identifierDelim)
 }
 
 // ImageRefAnnotation creates a map containing the key 'org.opencontainers.image.ref.name' with the provided value.


### PR DESCRIPTION
This pull request exposes a method to parse an string representation of the layout.Identifier() 

Considering an **image identifier**  with the format `[path]@[digest]`  a new method is expose to return an `layout.Identifier`

``` mermaid
classDiagram

class layout {
   ParseIdentifier(identifier string) (Identifier, error) 
}
```

Fixes #179