### PR TITLE
Feature: override media types for layout and remote

### DIFF
--- a/image.go
+++ b/image.go
@@ -5,33 +5,12 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
-
-var NormalizedDateTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
-
-type SaveDiagnostic struct {
-	ImageName string
-	Cause     error
-}
-
-type SaveError struct {
-	Errors []SaveDiagnostic
-}
-
-func (e SaveError) Error() string {
-	var errors []string
-	for _, d := range e.Errors {
-		errors = append(errors, fmt.Sprintf("[%s: %s]", d.ImageName, d.Cause.Error()))
-	}
-	return fmt.Sprintf("failed to write image to the following tags: %s", strings.Join(errors, ","))
-}
-
-// Platform represents the target arch/os/os_version for an image construction and querying.
-type Platform struct {
-	Architecture string
-	OS           string
-	OSVersion    string
-}
 
 type Image interface {
 	// getters
@@ -90,3 +69,109 @@ type Image interface {
 }
 
 type Identifier fmt.Stringer
+
+// Platform represents the target arch/os/os_version for an image construction and querying.
+type Platform struct {
+	Architecture string
+	OS           string
+	OSVersion    string
+}
+
+type MediaTypes string
+
+const (
+	DefaultTypes MediaTypes = ""
+	OCITypes     MediaTypes = "oci"
+	DockerTypes  MediaTypes = "docker"
+)
+
+func (t MediaTypes) ManifestType() types.MediaType {
+	if t == DockerTypes {
+		return types.DockerManifestSchema2
+	}
+	return types.OCIManifestSchema1
+}
+
+func (t MediaTypes) ConfigType() types.MediaType {
+	if t == DockerTypes {
+		return types.DockerConfigJSON
+	}
+	return types.OCIConfigJSON
+}
+
+func (t MediaTypes) LayerType() types.MediaType {
+	if t == DockerTypes {
+		return types.DockerLayer
+	}
+	return types.OCILayer
+}
+
+// OverrideMediaTypes mutates the provided v1.Image to use the desired media types
+// in the image manifest and config files (including the layers referenced in the manifest)
+func OverrideMediaTypes(base v1.Image, mediaTypes MediaTypes) (v1.Image, error) {
+	if mediaTypes == DefaultTypes {
+		// without media types option, default to original media types
+		return base, nil
+	}
+
+	// manifest media type
+	image := mutate.MediaType(empty.Image, mediaTypes.ManifestType())
+	// update empty image with base config
+	config, err := base.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	config.RootFS.DiffIDs = make([]v1.Hash, 0)
+	image, err = mutate.ConfigFile(image, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// config media type
+	image = mutate.ConfigMediaType(image, mediaTypes.ConfigType())
+
+	// layers media type
+	layers, err := base.Layers()
+	if err != nil {
+		return nil, err
+	}
+	additions := layersAddendum(layers, mediaTypes.LayerType())
+	image, err = mutate.Append(image, additions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return image, nil
+}
+
+// layersAddendum creates an Addendum array with the given layers
+// and the desired media type
+func layersAddendum(layers []v1.Layer, mediaType types.MediaType) []mutate.Addendum {
+	additions := make([]mutate.Addendum, 0)
+	for _, layer := range layers {
+		additions = append(additions, mutate.Addendum{
+			MediaType: mediaType,
+			Layer:     layer,
+		})
+	}
+	return additions
+}
+
+var NormalizedDateTime = time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)
+
+type SaveDiagnostic struct {
+	ImageName string
+	Cause     error
+}
+
+type SaveError struct {
+	Errors []SaveDiagnostic
+}
+
+func (e SaveError) Error() string {
+	var errors []string
+	for _, d := range e.Errors {
+		errors = append(errors, fmt.Sprintf("[%s: %s]", d.ImageName, d.Cause.Error()))
+	}
+	return fmt.Sprintf("failed to write image to the following tags: %s", strings.Join(errors, ","))
+}

--- a/image.go
+++ b/image.go
@@ -77,39 +77,52 @@ type Platform struct {
 	OSVersion    string
 }
 
-type MediaTypes string
+type MediaTypes int
 
 const (
-	DefaultTypes MediaTypes = ""
-	OCITypes     MediaTypes = "oci"
-	DockerTypes  MediaTypes = "docker"
+	MissingTypes MediaTypes = iota
+	DefaultTypes
+	OCITypes
+	DockerTypes
 )
 
 func (t MediaTypes) ManifestType() types.MediaType {
-	if t == DockerTypes {
+	switch t {
+	case OCITypes:
+		return types.OCIManifestSchema1
+	case DockerTypes:
 		return types.DockerManifestSchema2
+	default:
+		return ""
 	}
-	return types.OCIManifestSchema1
 }
 
 func (t MediaTypes) ConfigType() types.MediaType {
-	if t == DockerTypes {
+	switch t {
+	case OCITypes:
+		return types.OCIConfigJSON
+	case DockerTypes:
 		return types.DockerConfigJSON
+	default:
+		return ""
 	}
-	return types.OCIConfigJSON
 }
 
 func (t MediaTypes) LayerType() types.MediaType {
-	if t == DockerTypes {
+	switch t {
+	case OCITypes:
+		return types.OCILayer
+	case DockerTypes:
 		return types.DockerLayer
+	default:
+		return ""
 	}
-	return types.OCILayer
 }
 
 // OverrideMediaTypes mutates the provided v1.Image to use the desired media types
 // in the image manifest and config files (including the layers referenced in the manifest)
 func OverrideMediaTypes(base v1.Image, mediaTypes MediaTypes) (v1.Image, error) {
-	if mediaTypes == DefaultTypes {
+	if mediaTypes == DefaultTypes || mediaTypes == MissingTypes {
 		// without media types option, default to original media types
 		return base, nil
 	}

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -255,6 +255,24 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
+		when("#WithMediaTypes", func() {
+			it("sets the requested media types", func() {
+				img, err := layout.NewImage(
+					imagePath,
+					layout.WithMediaTypes(imgutil.DockerTypes),
+				)
+				h.AssertNil(t, err)
+				h.AssertDockerMediaTypes(t, img) // before saving
+				// add a random layer
+				path, diffID, _ := h.RandomLayer(t, tmpDir)
+				err = img.AddLayerWithDiffID(path, diffID)
+				h.AssertNil(t, err)
+				h.AssertDockerMediaTypes(t, img) // after adding a layer
+				h.AssertNil(t, img.Save())
+				h.AssertDockerMediaTypes(t, img) // after saving
+			})
+		})
+
 		when("#WithPreviousImage", func() {
 			var (
 				layerDiffID       string

--- a/layout/new.go
+++ b/layout/new.go
@@ -57,10 +57,10 @@ func NewImage(path string, ops ...ImageOption) (*Image, error) {
 		ri.createdAt = imageOpts.createdAt
 	}
 
-	if imageOpts.mediaTypes != "" {
-		ri.requestedMediaTypes = imageOpts.mediaTypes
+	if imageOpts.mediaTypes == imgutil.MissingTypes {
+		ri.requestedMediaTypes = imgutil.OCITypes
 	} else {
-		ri.requestedMediaTypes = imgutil.OCITypes // without media types option, default to oci media type
+		ri.requestedMediaTypes = imageOpts.mediaTypes
 	}
 	if err = ri.setUnderlyingImage(ri.Image); err != nil { // update media types
 		return nil, err

--- a/layout/options.go
+++ b/layout/options.go
@@ -16,6 +16,7 @@ type options struct {
 	baseImagePath string
 	prevImagePath string
 	createdAt     time.Time
+	mediaTypes    imgutil.MediaTypes
 }
 
 // FromBaseImage loads the given image as the config and layers for the new image.
@@ -27,7 +28,7 @@ func FromBaseImage(base v1.Image) ImageOption {
 	}
 }
 
-// FromBaseImagePath loads an existing image as the config and layers for the new underlyingImage.
+// FromBaseImagePath (layout only) loads an existing image as the config and layers for the new underlyingImage.
 // Ignored if underlyingImage is not found.
 func FromBaseImagePath(path string) ImageOption {
 	return func(i *options) error {
@@ -51,6 +52,15 @@ func WithCreatedAt(createdAt time.Time) ImageOption {
 func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	return func(i *options) error {
 		i.platform = platform
+		return nil
+	}
+}
+
+// WithMediaTypes lets a caller set the desired media types for the image manifest and config files,
+// including the layers referenced in the manifest, to be either OCI media types or Docker media types.
+func WithMediaTypes(requested imgutil.MediaTypes) ImageOption {
+	return func(i *options) error {
+		i.mediaTypes = requested
 		return nil
 	}
 }

--- a/layout/save.go
+++ b/layout/save.go
@@ -69,10 +69,10 @@ func (i *Image) SaveAs(name string, additionalNames ...string) error {
 
 // mutateCreatedAt mutates the provided v1.Image to have the provided v1.Time and wraps the result
 // into a layout.Image (requires for override methods like Layers()
-func (i *Image) mutateCreatedAt(base v1.Image, created v1.Time) error { // FIXME: this function doesn't need arguments
+func (i *Image) mutateCreatedAt(base v1.Image, created v1.Time) error { // FIXME: this function doesn't need arguments; we should also probably do this mutation at the time of image instantiation instead of at the point of saving
 	image, err := mutate.CreatedAt(i.Image, v1.Time{Time: i.createdAt})
 	if err != nil {
 		return err
 	}
-	return i.mutateImage(image)
+	return i.setUnderlyingImage(image)
 }

--- a/layout/sparse/new.go
+++ b/layout/sparse/new.go
@@ -1,0 +1,21 @@
+package sparse
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/buildpacks/imgutil/layout"
+)
+
+// NewImage returns a new Image saved on disk that can be modified
+func NewImage(path string, from v1.Image, ops ...layout.ImageOption) (*Image, error) {
+	allOps := append([]layout.ImageOption{layout.FromBaseImage(from)}, ops...)
+	img, err := layout.NewImage(path, allOps...)
+	if err != nil {
+		return nil, err
+	}
+
+	image := &Image{
+		Image: *img,
+	}
+	return image, nil
+}

--- a/layout/sparse/options.go
+++ b/layout/sparse/options.go
@@ -1,0 +1,1 @@
+package sparse

--- a/layout/sparse/save.go
+++ b/layout/sparse/save.go
@@ -1,0 +1,38 @@
+package sparse
+
+import (
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+
+	"github.com/buildpacks/imgutil"
+	"github.com/buildpacks/imgutil/layout"
+)
+
+func (i *Image) Save(additionalNames ...string) error {
+	return i.SaveAs(i.Name(), additionalNames...)
+}
+
+func (i *Image) SaveAs(name string, additionalNames ...string) error {
+	var diagnostics []imgutil.SaveDiagnostic
+
+	refName, _ := i.Image.GetAnnotateRefName()
+	annotations := layout.ImageRefAnnotation(refName)
+
+	pathsToSave := append([]string{name}, additionalNames...)
+	for _, path := range pathsToSave {
+		layoutPath, err := layout.Write(path, empty.Index)
+		if err != nil {
+			return err
+		}
+
+		err = layoutPath.AppendImage(i, layout.WithoutLayers(), layout.WithAnnotations(annotations))
+		if err != nil {
+			diagnostics = append(diagnostics, imgutil.SaveDiagnostic{ImageName: name, Cause: err})
+		}
+	}
+
+	if len(diagnostics) > 0 {
+		return imgutil.SaveError{Errors: diagnostics}
+	}
+
+	return nil
+}

--- a/layout/sparse/sparse.go
+++ b/layout/sparse/sparse.go
@@ -1,9 +1,6 @@
 package sparse
 
 import (
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
-
 	"github.com/buildpacks/imgutil/layout"
 
 	"github.com/buildpacks/imgutil"
@@ -11,51 +8,8 @@ import (
 
 var _ imgutil.Image = (*Image)(nil)
 
-// Image is a struct created to overrides the Save() method of the image.
-// a sparse Image is saved on disk but does not include any layers in the `blobs` directory.
+// Image is a struct created to override the Save() method of a layout image,
+// so that when the image is saved to disk, it does not include any layers in the `blobs` directory.
 type Image struct {
 	layout.Image
-}
-
-// NewImage returns a new Image saved on disk that can be modified
-func NewImage(path string, from v1.Image) (*Image, error) {
-	img, err := layout.NewImage(path, layout.FromBaseImage(from))
-	if err != nil {
-		return nil, err
-	}
-
-	image := &Image{
-		Image: *img,
-	}
-	return image, nil
-}
-
-func (i *Image) Save(additionalNames ...string) error {
-	return i.SaveAs(i.Name(), additionalNames...)
-}
-
-func (i *Image) SaveAs(name string, additionalNames ...string) error {
-	var diagnostics []imgutil.SaveDiagnostic
-
-	refName, _ := i.Image.GetAnnotateRefName()
-	annotations := layout.ImageRefAnnotation(refName)
-
-	pathsToSave := append([]string{name}, additionalNames...)
-	for _, path := range pathsToSave {
-		layoutPath, err := layout.Write(path, empty.Index)
-		if err != nil {
-			return err
-		}
-
-		err = layoutPath.AppendImage(i, layout.WithoutLayers(), layout.WithAnnotations(annotations))
-		if err != nil {
-			diagnostics = append(diagnostics, imgutil.SaveDiagnostic{ImageName: name, Cause: err})
-		}
-	}
-
-	if len(diagnostics) > 0 {
-		return imgutil.SaveError{Errors: diagnostics}
-	}
-
-	return nil
 }

--- a/layout/write.go
+++ b/layout/write.go
@@ -87,8 +87,6 @@ func (l Path) writeImageWithoutLayers(img v1.Image, annotations map[string]strin
 	return l.AppendDescriptor(desc)
 }
 
-// appendImage overrides the writeLayers operation from ggcr library.
-// calls the Layers() method on the mutateImage which is handling the logic to skip layers when it is required
 func (l Path) appendImage(img v1.Image, annotations map[string]string) error {
 	layers, err := img.Layers()
 	if err != nil {

--- a/remote/new.go
+++ b/remote/new.go
@@ -76,9 +76,7 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (*Im
 		ri.createdAt = imageOpts.createdAt
 	}
 
-	if imageOpts.mediaTypes != "" {
-		ri.requestedMediaTypes = imageOpts.mediaTypes
-	}
+	ri.requestedMediaTypes = imageOpts.mediaTypes
 	if err = ri.setUnderlyingImage(ri.image); err != nil { // update media types
 		return nil, err
 	}

--- a/remote/new.go
+++ b/remote/new.go
@@ -76,6 +76,13 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (*Im
 		ri.createdAt = imageOpts.createdAt
 	}
 
+	if imageOpts.mediaTypes != "" {
+		ri.requestedMediaTypes = imageOpts.mediaTypes
+	}
+	if err = ri.setUnderlyingImage(ri.image); err != nil { // update media types
+		return nil, err
+	}
+
 	return ri, nil
 }
 
@@ -288,4 +295,29 @@ func processBaseImageOption(ri *Image, baseImageRepoName string, platform imguti
 	ri.image = baseImage
 
 	return nil
+}
+
+// setUnderlyingImage wraps the provided v1.Image into a layout.Image and sets it as the underlying image for the receiving layout.Image
+func (i *Image) setUnderlyingImage(base v1.Image) error {
+	manifest, err := base.Manifest()
+	if err != nil {
+		return err
+	}
+	if i.requestedMediaTypesMatch(manifest) {
+		i.image = base
+		return nil
+	}
+	// provided v1.Image media types differ from requested, override them
+	newBase, err := imgutil.OverrideMediaTypes(base, i.requestedMediaTypes)
+	if err != nil {
+		return err
+	}
+	i.image = newBase
+	return nil
+}
+
+// requestedMediaTypesMatch returns true if the manifest and config file use the requested media types
+func (i *Image) requestedMediaTypesMatch(manifest *v1.Manifest) bool {
+	return manifest.MediaType == i.requestedMediaTypes.ManifestType() &&
+		manifest.Config.MediaType == i.requestedMediaTypes.ConfigType()
 }

--- a/remote/options.go
+++ b/remote/options.go
@@ -15,9 +15,10 @@ type options struct {
 	createdAt           time.Time
 	addEmptyLayerOnSave bool
 	registrySettings    map[string]registrySetting
+	mediaTypes          imgutil.MediaTypes
 }
 
-// AddEmptyLayerOnSave adds an empty layer before saving if the image has no layer at all.
+// AddEmptyLayerOnSave (remote only) adds an empty layer before saving if the image has no layer at all.
 // This option is useful when exporting to registries that do not allow saving an image without layers,
 // for example: gcr.io
 func AddEmptyLayerOnSave() ImageOption {
@@ -55,6 +56,15 @@ func WithDefaultPlatform(platform imgutil.Platform) ImageOption {
 	}
 }
 
+// WithMediaTypes lets a caller set the desired media types for the image manifest and config files,
+// including the layers referenced in the manifest, to be either OCI media types or Docker media types.
+func WithMediaTypes(requested imgutil.MediaTypes) ImageOption {
+	return func(i *options) error {
+		i.mediaTypes = requested
+		return nil
+	}
+}
+
 // WithPreviousImage loads an existing image as a source for reusable layers.
 // Use with ReuseLayer().
 // Ignored if image is not found.
@@ -65,7 +75,7 @@ func WithPreviousImage(imageName string) ImageOption {
 	}
 }
 
-// WithRegistrySetting registers options to use when accessing images in a registry in order to construct
+// WithRegistrySetting (remote only) registers options to use when accessing images in a registry in order to construct
 // the image. The referenced images could include the base image, a previous image, or the image itself.
 func WithRegistrySetting(repository string, insecure, insecureSkipVerify bool) ImageOption {
 	return func(opts *options) error {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -535,6 +535,27 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(h.FetchManifestLayers(t, repoName)), 1)
 			})
 		})
+
+		when("#WithMediaTypes", func() {
+			it("sets the requested media types", func() {
+				img, err := remote.NewImage(
+					newTestImageName(),
+					authn.DefaultKeychain,
+					remote.WithMediaTypes(imgutil.OCITypes),
+				)
+				h.AssertNil(t, err)
+				h.AssertOCIMediaTypes(t, img.UnderlyingImage()) // before saving
+				// add a random layer
+				newLayerPath, err := h.CreateSingleFileLayerTar("/new-layer.txt", "new-layer", "linux")
+				h.AssertNil(t, err)
+				defer os.Remove(newLayerPath)
+				err = img.AddLayer(newLayerPath)
+				h.AssertNil(t, err)
+				h.AssertOCIMediaTypes(t, img.UnderlyingImage()) // after adding a layer
+				h.AssertNil(t, img.Save())
+				h.AssertOCIMediaTypes(t, img.UnderlyingImage()) // after saving
+			})
+		})
 	})
 
 	when("#WorkingDir", func() {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -509,6 +509,23 @@ func AssertOCIMediaTypes(t *testing.T, image v1.Image) {
 	}
 }
 
+func AssertDockerMediaTypes(t *testing.T, image v1.Image) {
+	t.Helper()
+
+	mediaType, err := image.MediaType()
+	AssertNil(t, err)
+	AssertEq(t, mediaType, types.DockerManifestSchema2)
+
+	manifest, err := image.Manifest()
+	AssertNil(t, err)
+	AssertNotEq(t, manifest.MediaType, "")
+	AssertEq(t, manifest.Config.MediaType, types.DockerConfigJSON)
+
+	for _, layer := range manifest.Layers {
+		AssertEq(t, layer.MediaType, types.DockerLayer)
+	}
+}
+
 func ReadIndexManifest(t *testing.T, path string) *v1.IndexManifest {
 	indexPath := filepath.Join(path, "index.json")
 	AssertPathExists(t, filepath.Join(path, "oci-layout"))


### PR DESCRIPTION
This will help in a couple of cases:
* We can delete the [internal/selective](https://github.com/buildpacks/lifecycle/tree/main/internal/selective) package in the lifecycle and use layout/sparse instead (with media type option)
* If we desire to continue publishing lifecycle images that have docker media types (now that `gcr.io/distroless/static` has updated), we can do so

This builds off of refactor/file-organization so branching off of that until that one is merged