### PR TITLE
add Validate function

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -307,6 +307,10 @@ func (i *Image) Found() bool {
 	return !i.deleted
 }
 
+func (i *Image) Valid() bool {
+	return !i.deleted
+}
+
 func (i *Image) AnnotateRefName(refName string) error {
 	i.refName = refName
 	return nil

--- a/image.go
+++ b/image.go
@@ -21,6 +21,8 @@ type Image interface {
 	Env(key string) (string, error)
 	// Found tells whether the image exists in the repository by `Name()`.
 	Found() bool
+	// Valid returns true if the image is well formed (e.g. all manifest layers exist on the registry).
+	Valid() bool
 	GetAnnotateRefName() (string, error)
 	// GetLayer retrieves layer by diff id. Returns a reader of the uncompressed contents of the layer.
 	GetLayer(diffID string) (io.ReadCloser, error)

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -87,6 +87,10 @@ func (i *Image) Found() bool {
 	return ImageExists(i.path)
 }
 
+func (i *Image) Valid() bool {
+	return i.Found()
+}
+
 func ImageExists(path string) bool {
 	if !pathExists(path) {
 		return false

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -912,6 +912,53 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
+	when("#Valid", func() {
+		var image *layout.Image
+
+		it.Before(func() {
+			imagePath = filepath.Join(tmpDir, "found-image")
+			image, err = layout.NewImage(imagePath)
+			h.AssertNil(t, err)
+		})
+
+		it.After(func() {
+			os.RemoveAll(imagePath)
+		})
+
+		when("image doesn't exist on disk", func() {
+			it.Before(func() {
+				imagePath = filepath.Join(tmpDir, "non-exist-image")
+				image, err = layout.NewImage(imagePath)
+				h.AssertNil(t, err)
+			})
+
+			it("returns false", func() {
+				h.AssertTrue(t, func() bool {
+					return !image.Found()
+				})
+			})
+		})
+
+		when("image exists on disk", func() {
+			it.Before(func() {
+				imagePath = filepath.Join(testDataDir, "my-previous-image")
+				image, err = layout.NewImage(imagePath)
+				h.AssertNil(t, err)
+			})
+
+			it.After(func() {
+				// We don't want to delete testdata/my-previous-image
+				imagePath = ""
+			})
+
+			it("returns true", func() {
+				h.AssertTrue(t, func() bool {
+					return image.Found()
+				})
+			})
+		})
+	})
+
 	when("#Delete", func() {
 		var image *layout.Image
 

--- a/local/local.go
+++ b/local/local.go
@@ -72,6 +72,10 @@ func (i *Image) Found() bool {
 	return i.inspect.ID != ""
 }
 
+func (i *Image) Valid() bool {
+	return i.Found()
+}
+
 func (i *Image) GetAnnotateRefName() (string, error) {
 	return "", nil
 }

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -174,7 +174,7 @@ func (r *DockerRegistry) Start(t *testing.T) {
 
 	if r.username != "" {
 		// Write Docker config and configure auth headers
-		writeDockerConfig(t, r.DockerDirectory, r.Host, r.Port, r.encodedAuth())
+		writeDockerConfig(t, r.DockerDirectory, r.Host, r.Port, r.EncodedAuth())
 	}
 }
 
@@ -294,7 +294,7 @@ func DockerHostname(t *testing.T) string {
 	return "localhost"
 }
 
-func (r *DockerRegistry) encodedAuth() string {
+func (r *DockerRegistry) EncodedAuth() string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", r.username, r.password)))
 }
 


### PR DESCRIPTION
This adds a new `Validate` function that can be used to validate image contents in a registry. For remote images, `Validate` invokes go-containerregistry's validate function with the `Fast` option enabled, so it verifies the existence of layers via HTTP HEAD requests. For layout and local images, `Validate` is just an alias for `Found`.

We will use this function in the lifecycle to address https://github.com/buildpacks/lifecycle/issues/1044