### PR TITLE
Add ability to specify image config when instantiating new image

### DIFF
--- a/local/new.go
+++ b/local/new.go
@@ -73,6 +73,10 @@ func NewImage(repoName string, dockerClient DockerClient, ops ...ImageOption) (*
 		image.createdAt = imageOpts.createdAt
 	}
 
+	if imageOpts.config != nil {
+		image.inspect.Config = imageOpts.config
+	}
+
 	return image, nil
 }
 

--- a/local/options.go
+++ b/local/options.go
@@ -3,6 +3,8 @@ package local
 import (
 	"time"
 
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/buildpacks/imgutil"
 )
 
@@ -13,6 +15,7 @@ type options struct {
 	baseImageRepoName string
 	prevImageRepoName string
 	createdAt         time.Time
+	config            *container.Config
 }
 
 // FromBaseImage loads an existing image as the config and layers for the new image.
@@ -29,6 +32,13 @@ func FromBaseImage(imageName string) ImageOption {
 func WithCreatedAt(createdAt time.Time) ImageOption {
 	return func(opts *options) error {
 		opts.createdAt = createdAt
+		return nil
+	}
+}
+
+func WithConfig(config *container.Config) ImageOption {
+	return func(opts *options) error {
+		opts.config = config
 		return nil
 	}
 }

--- a/remote/new.go
+++ b/remote/new.go
@@ -76,6 +76,12 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (*Im
 		ri.createdAt = imageOpts.createdAt
 	}
 
+	if imageOpts.config != nil {
+		if ri.image, err = mutate.Config(ri.image, *imageOpts.config); err != nil {
+			return nil, err
+		}
+	}
+
 	ri.requestedMediaTypes = imageOpts.mediaTypes
 	if err = ri.setUnderlyingImage(ri.image); err != nil { // update media types
 		return nil, err

--- a/remote/options.go
+++ b/remote/options.go
@@ -3,6 +3,8 @@ package remote
 import (
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
 	"github.com/buildpacks/imgutil"
 )
 
@@ -16,6 +18,7 @@ type options struct {
 	addEmptyLayerOnSave bool
 	registrySettings    map[string]registrySetting
 	mediaTypes          imgutil.MediaTypes
+	config              *v1.Config
 }
 
 // AddEmptyLayerOnSave (remote only) adds an empty layer before saving if the image has no layer at all.
@@ -42,6 +45,13 @@ func FromBaseImage(imageName string) ImageOption {
 func WithCreatedAt(createdAt time.Time) ImageOption {
 	return func(opts *options) error {
 		opts.createdAt = createdAt
+		return nil
+	}
+}
+
+func WithConfig(config *v1.Config) ImageOption {
+	return func(opts *options) error {
+		opts.config = config
 		return nil
 	}
 }


### PR DESCRIPTION
Needed for https://github.com/buildpacks/lifecycle/pull/1055

This will allow us to provide the config of the extended run image when constructing the image to export.