### PR TITLE
Fix bug in remote.Valid()

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -116,7 +116,19 @@ func (i *Image) valid() error {
 	if err != nil {
 		return err
 	}
-	img, err := remote.Image(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	desc, err := remote.Get(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	if err != nil {
+		return err
+	}
+
+	if desc.MediaType == types.OCIImageIndex || desc.MediaType == types.DockerManifestList {
+		index, err := desc.ImageIndex()
+		if err != nil {
+			return err
+		}
+		return validate.Index(index, validate.Fast)
+	}
+	img, err := desc.Image()
 	if err != nil {
 		return err
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1676,6 +1676,15 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, image.Valid(), false)
 			})
 		})
+
+		when("windows image index", func() {
+			it("returns true", func() {
+				ref := "mcr.microsoft.com/windows/nanoserver@sha256:eea54849888c8070ea35f8df39b3a5e126bc9a5bd30afdcad6f430408b2c786d"
+				image, err := remote.NewImage(ref, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+				h.AssertEq(t, image.Valid(), true)
+			})
+		})
 	})
 
 	when("#Delete", func() {


### PR DESCRIPTION
The remote.Valid() function assumes the platform is always linux/amd64. This was causing validation to fail for an index reference that only contains a windows manifest. This commit fixes the issue calling the ggcr validate.Index() function when the ref is an index.