### PR TITLE
Fixed version of the linter 1.51.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ format: install-goimports
 
 install-golangci-lint:
 	@echo "> Installing golangci-lint..."
-	cd tools && $(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd tools && $(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.1
 
 lint: install-golangci-lint
 	@echo "> Linting code..."

--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -3,18 +3,14 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
-
 	dockerclient "github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
+	"os"
+	"testing"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/local"
@@ -29,9 +25,7 @@ func newTestImageName() string {
 }
 
 func TestAcceptance(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	dockerConfigDir, err := ioutil.TempDir("", "test.docker.config.dir")
+	dockerConfigDir, err := os.MkdirTemp("", "test.docker.config.dir")
 	h.AssertNil(t, err)
 	defer os.RemoveAll(dockerConfigDir)
 

--- a/fakes/image.go
+++ b/fakes/image.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -264,7 +263,7 @@ func (i *Image) Save(additionalNames ...string) error {
 
 func (i *Image) SaveAs(name string, additionalNames ...string) error {
 	var err error
-	i.layerDir, err = ioutil.TempDir("", "fake-image")
+	i.layerDir, err = os.MkdirTemp("", "fake-image")
 	if err != nil {
 		return err
 	}

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -3,12 +3,14 @@ package fakes_test
 import (
 	"archive/tar"
 	"fmt"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
+
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/fakes"

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -3,16 +3,12 @@ package fakes_test
 import (
 	"archive/tar"
 	"fmt"
-	"io/ioutil"
-	"math/rand"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
-	"time"
-
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/fakes"
@@ -26,8 +22,6 @@ func newRepoName() string {
 }
 
 func TestFake(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	localTestRegistry = h.NewDockerRegistry()
 	localTestRegistry.Start(t)
 	defer localTestRegistry.Stop(t)
@@ -154,7 +148,7 @@ Layers
 }
 
 func createLayerTar(contents map[string]string) (string, error) {
-	file, err := ioutil.TempFile("", "layer-*.tar")
+	file, err := os.CreateTemp("", "layer-*.tar")
 	if err != nil {
 		return "", nil
 	}

--- a/layer/windows_writer_test.go
+++ b/layer/windows_writer_test.go
@@ -3,7 +3,6 @@ package layer_test
 import (
 	"archive/tar"
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,7 +22,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 		it("writes required entries", func() {
 			var err error
 
-			f, err := ioutil.TempFile("", "windows-writer.tar")
+			f, err := os.CreateTemp("", "windows-writer.tar")
 			h.AssertNil(t, err)
 			defer func() { f.Close(); os.Remove(f.Name()) }()
 
@@ -69,7 +68,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 			it("only writes parents once", func() {
 				var err error
 
-				f, err := ioutil.TempFile("", "windows-writer.tar")
+				f, err := os.CreateTemp("", "windows-writer.tar")
 				h.AssertNil(t, err)
 				defer func() { f.Close(); os.Remove(f.Name()) }()
 
@@ -145,7 +144,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 				it("writes administrator-owned entries", func() {
 					var err error
 
-					f, err := ioutil.TempFile("", "windows-writer.tar")
+					f, err := os.CreateTemp("", "windows-writer.tar")
 					h.AssertNil(t, err)
 					defer func() { f.Close(); os.Remove(f.Name()) }()
 
@@ -183,7 +182,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 				it("writes user-owned entries", func() {
 					var err error
 
-					f, err := ioutil.TempFile("", "windows-writer.tar")
+					f, err := os.CreateTemp("", "windows-writer.tar")
 					h.AssertNil(t, err)
 					defer func() { f.Close(); os.Remove(f.Name()) }()
 
@@ -216,7 +215,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 				it("writes no new records", func() {
 					var err error
 
-					f, err := ioutil.TempFile("", "windows-writer.tar")
+					f, err := os.CreateTemp("", "windows-writer.tar")
 					h.AssertNil(t, err)
 					defer func() { f.Close(); os.Remove(f.Name()) }()
 
@@ -249,7 +248,7 @@ func testWindowsWriter(t *testing.T, when spec.G, it spec.S) {
 		it("writes required parent dirs on empty layer", func() {
 			var err error
 
-			f, err := ioutil.TempFile("", "windows-writer.tar")
+			f, err := os.CreateTemp("", "windows-writer.tar")
 			h.AssertNil(t, err)
 			defer func() { f.Close(); os.Remove(f.Name()) }()
 

--- a/layout/write.go
+++ b/layout/write.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -161,7 +160,7 @@ func (l Path) writeLayer(layer v1.Layer) error {
 	if errors.Is(err, stream.ErrNotComputed) {
 		// Allow digest errors, since streams may not have calculated the hash
 		// yet. Instead, use an empty value, which will be transformed into a
-		// random file name with `ioutil.TempFile` and the final digest will be
+		// random file name with `os.CreateTemp` and the final digest will be
 		// calculated after writing to a temp file and before renaming to the
 		// final path.
 		d = v1.Hash{Algorithm: "sha256", Hex: ""}
@@ -214,7 +213,7 @@ func (l Path) writeBlob(hash v1.Hash, size int64, rc io.ReadCloser, renamer func
 	// If a renamer func was provided write to a temporary file
 	open := func() (*os.File, error) { return os.Create(file) }
 	if renamer != nil {
-		open = func() (*os.File, error) { return ioutil.TempFile(dir, hash.Hex) }
+		open = func() (*os.File, error) { return os.CreateTemp(dir, hash.Hex) }
 	}
 	w, err := open()
 	if err != nil {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -30,8 +28,6 @@ var localTestRegistry *h.DockerRegistry
 
 // FIXME: relevant tests in this file should be moved into new_test.go and save_test.go to mirror the implementation
 func TestLocal(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
 	localTestRegistry = h.NewDockerRegistry()
 	localTestRegistry.Start(t)
 	defer localTestRegistry.Stop(t)
@@ -2004,7 +2000,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns errors from daemon", func() {
 				repoName := newTestImageName()
 
-				invalidLayerTarFile, err := ioutil.TempFile("", "daemon-error-test")
+				invalidLayerTarFile, err := os.CreateTemp("", "daemon-error-test")
 				h.AssertNil(t, err)
 				defer func() { invalidLayerTarFile.Close(); os.Remove(invalidLayerTarFile.Name()) }()
 

--- a/local/new.go
+++ b/local/new.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -214,7 +214,7 @@ func prepareNewWindowsImage(image *Image) error {
 		return err
 	}
 
-	layerFile, err := ioutil.TempFile("", "imgutil.local.image.windowsbaselayer")
+	layerFile, err := os.CreateTemp("", "imgutil.local.image.windowsbaselayer")
 	if err != nil {
 		return errors.Wrap(err, "creating temp file")
 	}

--- a/local/save.go
+++ b/local/save.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -191,7 +190,7 @@ func (i *Image) downloadBaseLayers() error {
 	}
 	defer ensureReaderClosed(imageReader)
 
-	tmpDir, err := ioutil.TempDir("", "imgutil.local.image.")
+	tmpDir, err := os.MkdirTemp("", "imgutil.local.image.")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
@@ -265,7 +264,7 @@ func checkResponseError(r io.Reader) error {
 
 // ensureReaderClosed drains and closes and reader, returning the first error
 func ensureReaderClosed(r io.ReadCloser) error {
-	_, err := io.Copy(ioutil.Discard, r)
+	_, err := io.Copy(io.Discard, r)
 	if closeErr := r.Close(); closeErr != nil && err == nil {
 		err = closeErr
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -2,9 +2,8 @@ package remote_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
-	"math/rand"
 	"os"
 	"strings"
 	"testing"
@@ -42,13 +41,11 @@ func newTestImageName(providedPrefix ...string) string {
 
 // FIXME: relevant tests in this file should be moved into new_test.go and save_test.go to mirror the implementation
 func TestRemote(t *testing.T) {
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	dockerConfigDir, err := ioutil.TempDir("", "test.docker.config.dir")
+	dockerConfigDir, err := os.MkdirTemp("", "test.docker.config.dir")
 	h.AssertNil(t, err)
 	defer os.RemoveAll(dockerConfigDir)
 
-	sharedRegistryHandler := registry.New(registry.Logger(log.New(ioutil.Discard, "", log.Lshortfile)))
+	sharedRegistryHandler := registry.New(registry.Logger(log.New(io.Discard, "", log.Lshortfile)))
 	dockerRegistry = h.NewDockerRegistry(h.WithAuth(dockerConfigDir), h.WithSharedHandler(sharedRegistryHandler))
 	dockerRegistry.Start(t)
 	defer dockerRegistry.Stop(t)
@@ -57,7 +54,7 @@ func TestRemote(t *testing.T) {
 	readonlyDockerRegistry.Start(t)
 	defer readonlyDockerRegistry.Stop(t)
 
-	customDockerConfigDir, err := ioutil.TempDir("", "test.docker.config.custom.dir")
+	customDockerConfigDir, err := os.MkdirTemp("", "test.docker.config.custom.dir")
 	h.AssertNil(t, err)
 	defer os.RemoveAll(customDockerConfigDir)
 	customRegistry = h.NewDockerRegistry(h.WithAuth(customDockerConfigDir), h.WithSharedHandler(sharedRegistryHandler),

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -135,7 +136,7 @@ func (r *DockerRegistry) Start(t *testing.T) {
 	// create registry handler, if not re-using a shared one
 	if r.regHandler == nil {
 		// change to os.Stderr for verbose output
-		logger := registry.Logger(log.New(ioutil.Discard, "registry ", log.Lshortfile))
+		logger := registry.Logger(log.New(io.Discard, "registry ", log.Lshortfile))
 		r.regHandler = registry.New(logger)
 	}
 
@@ -299,7 +300,7 @@ func (r *DockerRegistry) EncodedAuth() string {
 }
 
 func writeDockerConfig(t *testing.T, configDir, host, port, auth string) {
-	AssertNil(t, ioutil.WriteFile(
+	AssertNil(t, os.WriteFile(
 		filepath.Join(configDir, "config.json"),
 		[]byte(fmt.Sprintf(`{
 			  "auths": {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -185,7 +184,7 @@ func PullIfMissing(t *testing.T, docker dockercli.CommonAPIClient, ref string) {
 
 	AssertNil(t, checkResponseError(rc))
 
-	_, err = io.Copy(ioutil.Discard, rc)
+	_, err = io.Copy(io.Discard, rc)
 	AssertNil(t, err)
 }
 
@@ -224,7 +223,7 @@ func PushImage(t *testing.T, dockerCli dockercli.CommonAPIClient, refStr string)
 
 	AssertNil(t, checkResponseError(rc))
 
-	_, err = io.Copy(ioutil.Discard, rc)
+	_, err = io.Copy(io.Discard, rc)
 	AssertNil(t, err)
 }
 
@@ -298,7 +297,7 @@ func getLayerWriter(osType string, file *os.File) layerWriter {
 }
 
 func CreateSingleFileLayerTar(layerPath, txt, osType string) (string, error) {
-	tarFile, err := ioutil.TempFile("", "create-single-file-layer-tar-path")
+	tarFile, err := os.CreateTemp("", "create-single-file-layer-tar-path")
 	if err != nil {
 		return "", err
 	}
@@ -400,7 +399,7 @@ func StringElementAt(elements []string, offset int) string {
 }
 
 func checkResponseError(r io.Reader) error {
-	responseBytes, err := ioutil.ReadAll(r)
+	responseBytes, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/tools/bcdhive_generator/bcdhive_hivex.go
+++ b/tools/bcdhive_generator/bcdhive_hivex.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"github.com/gabriel-samfira/go-hivex"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/gabriel-samfira/go-hivex"
 	"github.com/pkg/errors"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/tools/go/packages"
@@ -68,7 +68,7 @@ type entry struct {
 }
 
 func HiveBCD() ([]byte, error) {
-	hiveFile, err := ioutil.TempFile("", "")
+	hiveFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
 	}

--- a/tools/bcdhive_generator/bcdhive_test.go
+++ b/tools/bcdhive_generator/bcdhive_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -51,7 +50,7 @@ func TestBaseLayerBCDActual(t *testing.T) {
 func assertIsBCDBaseLayer(t *testing.T, bcdBytes []byte) {
 	t.Helper()
 
-	hiveFile, err := ioutil.TempFile("", "")
+	hiveFile, err := os.CreateTemp("", "")
 	assert.NilError(t, err)
 	defer hiveFile.Close()
 	defer os.Remove(hiveFile.Name())


### PR DESCRIPTION
## Summary
I noticed that on [Lifecycle](https://github.com/buildpacks/lifecycle/blob/main/Makefile#L260) we are using a fixed version of the linter but on [Imgutil](https://github.com/buildpacks/imgutil/blob/main/Makefile#L18) we are using the latest one.
It can be risky having always the latest version (introduction of bugs and breaking changes)
So to have it aligned I added the fixed version on imgutil Makefile

## Output


#### Before

Whenever we download the linter we install the latest version

#### After

Now whenever we download the linter we install version 1.51.1 

## Documentation
<!-- If this change should be documented, please create an issue or PR on https://github.com/buildpacks/docs and link below. -->
<!-- NOTE: This can be added (by editing the issue) after the PR is opened. -->

- Should this change be documented?
    - [ ] Yes, see #___
    - [X] No

## Related
<!-- If this PR addresses an issue, please provide issue number below. -->

Resolves #___
