### PR TITLE
Set InsecureSkipVerify flag as the Insecure one

### DIFF
--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -3,14 +3,15 @@ package acceptance
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	dockerclient "github.com/docker/docker/client"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrremote "github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-	"os"
-	"testing"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/local"

--- a/remote/new.go
+++ b/remote/new.go
@@ -146,7 +146,7 @@ func prepareNewWindowsImage(ri *Image) error {
 func processPreviousImageOption(ri *Image, prevImageRepoName string, platform imgutil.Platform) error {
 	reg := getRegistry(prevImageRepoName, ri.registrySettings)
 
-	prevImage, err := NewV1Image(prevImageRepoName, ri.keychain, WithV1DefaultPlatform(platform), WithV1RegistrySetting(reg.insecure, reg.insecureSkipVerify))
+	prevImage, err := NewV1Image(prevImageRepoName, ri.keychain, WithV1DefaultPlatform(platform), WithV1RegistrySetting(reg.insecure))
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func newV1Image(keychain authn.Keychain, repoName string, platform imgutil.Platf
 
 	opts := []remote.Option{remote.WithAuth(auth), remote.WithPlatform(v1Platform)}
 	// #nosec G402
-	if reg.insecureSkipVerify {
+	if reg.insecure {
 		opts = append(opts, remote.WithTransport(&http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
@@ -276,7 +276,7 @@ func referenceForRepoName(keychain authn.Keychain, ref string, insecure bool) (n
 func processBaseImageOption(ri *Image, baseImageRepoName string, platform imgutil.Platform) error {
 	reg := getRegistry(baseImageRepoName, ri.registrySettings)
 	var err error
-	ri.image, err = NewV1Image(baseImageRepoName, ri.keychain, WithV1DefaultPlatform(platform), WithV1RegistrySetting(reg.insecure, reg.insecureSkipVerify))
+	ri.image, err = NewV1Image(baseImageRepoName, ri.keychain, WithV1DefaultPlatform(platform), WithV1RegistrySetting(reg.insecure))
 	if err != nil {
 		return err
 	}

--- a/remote/options.go
+++ b/remote/options.go
@@ -97,12 +97,12 @@ func WithPreviousImage(imageName string) ImageOption {
 
 // WithRegistrySetting (remote only) registers options to use when accessing images in a registry in order to construct
 // the image. The referenced images could include the base image, a previous image, or the image itself.
-func WithRegistrySetting(repository string, insecure, insecureSkipVerify bool) ImageOption {
+// insecure parameter allows image references to be fetched without TLS.
+func WithRegistrySetting(repository string, insecure bool) ImageOption {
 	return func(opts *options) error {
 		opts.registrySettings = make(map[string]registrySetting)
 		opts.registrySettings[repository] = registrySetting{
-			insecure:           insecure,
-			insecureSkipVerify: insecureSkipVerify,
+			insecure: insecure,
 		}
 		return nil
 	}
@@ -125,11 +125,10 @@ func WithV1DefaultPlatform(platform imgutil.Platform) V1ImageOption {
 }
 
 // WithV1RegistrySetting registers options to use when accessing images in a registry in order to construct a v1.Image.
-func WithV1RegistrySetting(insecure, insecureSkipVerify bool) V1ImageOption {
+func WithV1RegistrySetting(insecure bool) V1ImageOption {
 	return func(opts *v1Options) error {
 		opts.registrySetting = registrySetting{
-			insecure:           insecure,
-			insecureSkipVerify: insecureSkipVerify,
+			insecure: insecure,
 		}
 		return nil
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -37,8 +37,7 @@ type Image struct {
 }
 
 type registrySetting struct {
-	insecure           bool
-	insecureSkipVerify bool
+	insecure bool
 }
 
 // getters

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -206,7 +206,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 							repoName,
 							authn.DefaultKeychain,
 							remote.FromBaseImage("host.docker.internal/bar"),
-							remote.WithRegistrySetting("host.docker.internal", true, true))
+							remote.WithRegistrySetting("host.docker.internal", true))
 
 						h.AssertError(t, err, "http://")
 					})

--- a/tools/bcdhive_generator/bcdhive_hivex.go
+++ b/tools/bcdhive_generator/bcdhive_hivex.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/gabriel-samfira/go-hivex"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/gabriel-samfira/go-hivex"
 
 	"github.com/pkg/errors"
 	"golang.org/x/text/encoding/unicode"


### PR DESCRIPTION
This PR concerns the [insecure-registry RFC](https://github.com/buildpacks/rfcs/blob/main/text/0111-support-insecure-registries.md) implementation in the imgutil library.

In the [previous PR](https://github.com/buildpacks/imgutil/pull/154), a function`WithRegistrySetting` has been implemented with the possibility to activate or deactivate the `InsecureSkipVerify` flag.

[The RFC](https://github.com/buildpacks/rfcs/blob/main/text/0111-support-insecure-registries.md#how-it-works) wasn't very clear about the reason it needed to be permanently set as false/true so I tried to investigate a bit how other tools/libraries implemented it.
From Google:
```
// Insecure is an Option that allows image references to be fetched without TLS.
// This will also allow for untrusted (e.g. self-signed) certificates in cases where
// the default transport is used (i.e. when WithTransport is not used).
```
This implementation followed the one made by Google: https://github.com/google/go-containerregistry/blob/main/pkg/crane/options.go#L70 and https://github.com/google/go-containerregistry/blob/190ad0e4d556f199a07951d55124f8a394ebccd9/cmd/crane/cmd/root.go#L83 

With this PR, whenever we set a registry as `Insecure` we also disable the TLS verification.
