### PR TITLE
Add insecureSkipVerify in other missing functions

### DIFF
--- a/remote/new.go
+++ b/remote/new.go
@@ -1,7 +1,6 @@
 package remote
 
 import (
-	"crypto/tls"
 	"io"
 	"net/http"
 	"strings"
@@ -218,22 +217,14 @@ func newV1Image(keychain authn.Keychain, repoName string, platform imgutil.Platf
 		OSVersion:    platform.OSVersion,
 	}
 
-	opts := []remote.Option{remote.WithAuth(auth), remote.WithPlatform(v1Platform)}
-	// #nosec G402
-	if reg.insecure {
-		opts = append(opts, remote.WithTransport(&http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}))
-	} else {
-		opts = append(opts, remote.WithTransport(http.DefaultTransport))
-	}
-
 	var image v1.Image
 	for i := 0; i <= maxRetries; i++ {
 		time.Sleep(100 * time.Duration(i) * time.Millisecond) // wait if retrying
-		image, err = remote.Image(ref, opts...)
+		image, err = remote.Image(ref,
+			remote.WithAuth(auth),
+			remote.WithPlatform(v1Platform),
+			remote.WithTransport(getTransport(reg.insecure)),
+		)
 		if err != nil {
 			if err == io.EOF && i != maxRetries {
 				continue // retry if EOF

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -104,7 +104,7 @@ func (i *Image) found() (*v1.Descriptor, error) {
 	if err != nil {
 		return nil, err
 	}
-	return remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	return remote.Head(ref, remote.WithAuth(auth), remote.WithTransport(getTransport(reg.insecure)))
 }
 
 func (i *Image) Valid() bool {
@@ -117,7 +117,7 @@ func (i *Image) valid() error {
 	if err != nil {
 		return err
 	}
-	desc, err := remote.Get(ref, remote.WithAuth(auth), remote.WithTransport(http.DefaultTransport))
+	desc, err := remote.Get(ref, remote.WithAuth(auth), remote.WithTransport(getTransport(reg.insecure)))
 	if err != nil {
 		return err
 	}
@@ -454,7 +454,7 @@ func (i *Image) Delete() error {
 	if err != nil {
 		return err
 	}
-	return remote.Delete(ref, remote.WithAuth(auth))
+	return remote.Delete(ref, remote.WithAuth(auth), remote.WithTransport(getTransport(reg.insecure)))
 }
 
 func (i *Image) Rebase(baseTopLayer string, newBase imgutil.Image) error {

--- a/remote/save.go
+++ b/remote/save.go
@@ -1,7 +1,9 @@
 package remote
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -89,5 +91,22 @@ func (i *Image) doSave(imageName string) error {
 	if err != nil {
 		return err
 	}
-	return remote.Write(ref, i.image, remote.WithAuth(auth))
+
+	return remote.Write(ref, i.image, []remote.Option{
+		remote.WithAuth(auth),
+		remote.WithTransport(getTransport(reg.insecure)),
+	}...)
+}
+
+func getTransport(insecure bool) http.RoundTripper {
+	// #nosec G402
+	if insecure {
+		return &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
+	return http.DefaultTransport
 }

--- a/remote/save.go
+++ b/remote/save.go
@@ -92,10 +92,10 @@ func (i *Image) doSave(imageName string) error {
 		return err
 	}
 
-	return remote.Write(ref, i.image, []remote.Option{
+	return remote.Write(ref, i.image,
 		remote.WithAuth(auth),
 		remote.WithTransport(getTransport(reg.insecure)),
-	}...)
+	)
 }
 
 func getTransport(insecure bool) http.RoundTripper {


### PR DESCRIPTION
@jabrown85 [has spotted](https://github.com/buildpacks/lifecycle/pull/1140#issuecomment-1719849393) some points in the `imgutil` library where the `insecureSkipVerify` flag should be necessary.

This PR is addressing that.

Thank you @jabrown85!
