### PR TITLE
Initialize the map only once to support multiple registries

### DIFF
--- a/remote/options.go
+++ b/remote/options.go
@@ -100,10 +100,14 @@ func WithPreviousImage(imageName string) ImageOption {
 // insecure parameter allows image references to be fetched without TLS.
 func WithRegistrySetting(repository string, insecure bool) ImageOption {
 	return func(opts *options) error {
-		opts.registrySettings = make(map[string]registrySetting)
+		if len(opts.registrySettings) == 0 {
+			opts.registrySettings = make(map[string]registrySetting)
+		}
+
 		opts.registrySettings[repository] = registrySetting{
 			insecure: insecure,
 		}
+
 		return nil
 	}
 }

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -211,6 +211,18 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, err, "http://")
 					})
 
+					it("tries to pull the image from an insecure registry if WithRegistrySettings insecure has been set, it works with multiple registries", func() {
+						_, err := remote.NewImage(
+							repoName,
+							authn.DefaultKeychain,
+							remote.FromBaseImage("myother-insecure-registry.com/repo/superbase"),
+							remote.WithRegistrySetting("myregistry.domain.com", true),
+							remote.WithRegistrySetting("myother-insecure-registry.com", true),
+						)
+
+						h.AssertError(t, err, "http://myother-insecure-registry.com")
+					})
+
 					it("sets the initial state from a windows/amd64 base image", func() {
 						baseImageName := "mcr.microsoft.com/windows/nanoserver@sha256:06281772b6a561411d4b338820d94ab1028fdeb076c85350bbc01e80c4bfa2b4"
 						existingLayerSha := "sha256:26fd2d9d4c64a4f965bbc77939a454a31b607470f430b5d69fc21ded301fa55e"


### PR DESCRIPTION
This PR would fix the problem affecting the utilization of multiple insecure registries using the remote.WithRegistrySetting function.

With this PR we initialize the map only once.

Thanks to @jabrown85  to have spotted the problem https://github.com/buildpacks/imgutil/pull/219#issuecomment-1723712678 