### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,14 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+    groups:
+      # Group all minor/patch go dependencies into a single PR.
+      go-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Dependabot updates for GitHub Actions are now enabled, for parity with the other repos.

In addition, Go minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

Major updates, as well as security updates will still be opened as separate PRs. I've not grouped GitHub Actions update PRs, since the volume is typically much lower for those.

The custom open pull requests limit has been removed, since it is no longer necessary, as there won't be as many open PRs.

Lastly, the schedule has been changed from daily to weekly.

This reduces project maintenance toil (no more having to manually create combined update PRs), plus makes it less painful for contributors to subscribe to repository notifications (currently there is a lot of noise from Dependabot PRs being opened/auto-rebased etc).