### PR TITLE
Fix indentation in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    groups:
-      # Group all minor/patch go dependencies into a single PR.
-      go-dependencies:
-        update-types:
-          - "minor"
-          - "patch"
+  groups:
+    # Group all minor/patch go dependencies into a single PR.
+    go-dependencies:
+      update-types:
+        - "minor"
+        - "patch"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
The `groups` section added in #223 was indented incorrectly, resulting in Dependabot ignoring the `groups` section of the config.

It's not clear why the Dependabot config schema validation didn't highlight the error on the PR - perhaps because it doesn't run on forked PRs?