### PR TITLE
Use DriverStatus to check if containerd is used

### DIFF
--- a/local/save.go
+++ b/local/save.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -71,7 +70,14 @@ func usesContainerdStorage(docker DockerClient) bool {
 	if err != nil {
 		return false
 	}
-	return strings.Contains(info.Driver, "stargz")
+
+	for _, driverStatus := range info.DriverStatus {
+		if driverStatus[0] == "driver-type" && driverStatus[1] == "io.containerd.snapshotter.v1" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (i *Image) doSaveAs(name string) (types.ImageInspect, error) {


### PR DESCRIPTION
:wave: I stumbled on this code while reading https://github.com/moby/moby/issues/46746

This change looks at the DriverStatus that contains a "driver-type" equal to "io.containerd.snapshotter.v1" if the daemon uses containerd for storing images, this is slightly better than looking at the Driver. The Driver is "stargz" by default on Docker Desktop but a user can change this default value, they could use "overlayfs" for example, or any other containerd snapshotter.

@natalieparellano @jabrown85 