### PR TITLE
Use daemon or runtime provided arch instead of amd64

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -41,6 +41,7 @@ type DockerClient interface {
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	Info(ctx context.Context) (types.Info, error)
+	ServerVersion(ctx context.Context) (types.Version, error)
 }
 
 // getters

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -43,6 +43,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 	var (
 		dockerClient          client.CommonAPIClient
 		daemonOS              string
+		daemonArchitecture    string
 		runnableBaseImageName string
 	)
 
@@ -50,10 +51,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		var err error
 		dockerClient = h.DockerCli(t)
 
-		daemonInfo, err := dockerClient.Info(context.TODO())
+		versionInfo, err := dockerClient.ServerVersion(context.TODO())
 		h.AssertNil(t, err)
 
-		daemonOS = daemonInfo.OSType
+		daemonOS = versionInfo.Os
+		daemonArchitecture = versionInfo.Arch
 		runnableBaseImageName = h.RunnableBaseImage(daemonOS)
 
 		h.PullIfMissing(t, dockerClient, runnableBaseImageName)
@@ -79,11 +81,11 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
 				h.AssertNil(t, err)
 
-				daemonInfo, err := dockerClient.Info(context.TODO())
+				versionInfo, err := dockerClient.ServerVersion(context.TODO())
 				h.AssertNil(t, err)
 
-				h.AssertEq(t, inspect.Os, daemonInfo.OSType)
-				h.AssertEq(t, inspect.Architecture, "amd64")
+				h.AssertEq(t, inspect.Os, versionInfo.Os)
+				h.AssertEq(t, inspect.Architecture, versionInfo.Arch)
 				h.AssertEq(t, inspect.RootFS.Type, "layers")
 			})
 		})
@@ -210,7 +212,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, inspect.Os, daemonOS)
-						h.AssertEq(t, inspect.Architecture, "amd64")
+						h.AssertEq(t, inspect.Architecture, daemonArchitecture)
 						h.AssertEq(t, inspect.RootFS.Type, "layers")
 
 						h.AssertEq(t, img.Found(), true)

--- a/local/new.go
+++ b/local/new.go
@@ -86,14 +86,14 @@ func NewImage(repoName string, dockerClient DockerClient, ops ...ImageOption) (*
 }
 
 func defaultPlatform(dockerClient DockerClient) (imgutil.Platform, error) {
-	daemonInfo, err := dockerClient.Info(context.Background())
+	versionInfo, err := dockerClient.ServerVersion(context.Background())
 	if err != nil {
 		return imgutil.Platform{}, err
 	}
 
 	return imgutil.Platform{
-		OS:           daemonInfo.OSType,
-		Architecture: "amd64",
+		OS:           versionInfo.Os,
+		Architecture: versionInfo.Arch,
 	}, nil
 }
 

--- a/remote/new.go
+++ b/remote/new.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -93,7 +94,7 @@ func NewImage(repoName string, keychain authn.Keychain, ops ...ImageOption) (*Im
 func defaultPlatform() imgutil.Platform {
 	return imgutil.Platform{
 		OS:           "linux",
-		Architecture: "amd64",
+		Architecture: runtime.GOARCH,
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -102,7 +103,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				arch, err := img.Architecture()
 				h.AssertNil(t, err)
-				h.AssertEq(t, arch, "amd64")
+				h.AssertEq(t, arch, runtime.GOARCH)
 			})
 
 			it("fails to save to read-only registry", func() {
@@ -274,7 +275,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 						arch, err := img.Architecture()
 						h.AssertNil(t, err)
-						h.AssertEq(t, arch, "amd64")
+						h.AssertEq(t, arch, runtime.GOARCH)
 
 						readCloser, err := img.GetLayer(existingLayerSha)
 						h.AssertNil(t, err)


### PR DESCRIPTION
The current `defaultPlatform` functions sets the architecture to "amd64", which causes pack to use the `amd64` build image, and to install the `amd64` lifecycle, when creating a new builder from an `arm64` host with no docker daemon installed. 

This changes the default platform functions to use the docker daemon os and architecture for local images, and `runtime.GOARCH` as the architecture for new remote images.

The following log file is the output of a script that was used to identify the issue.
https://github.com/jericop/github-actions/blob/main/buildpacks/create-multi-arch-builders/standalone/imgutil-pr-232-verify-amd64-issue.sh.log

You can see that the script doesn't finish. You can also see that it downloads an `amd64` lifecycle rather than the `arm64` as expected.
https://github.com/jericop/github-actions/blob/main/buildpacks/create-multi-arch-builders/standalone/imgutil-pr-232-verify-amd64-issue.sh.log#L159

The following log file is the output of a script was used to identify that an updated version of pack that uses this fix.
https://github.com/jericop/github-actions/blob/main/buildpacks/create-multi-arch-builders/standalone/imgutil-pr-232-verify-fix.sh.log
