### PR TITLE
sparse: do not modify media type when unspecified

### DIFF
--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -157,7 +157,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					it("sets the initial state from a linux/arm base image", func() {
 						existingLayerSha := "sha256:5a0b973aa300cd2650869fd76d8546b361fcd6dfc77bd37b9d4f082cca9874e4"
 
-						img, err := layout.NewImage(imagePath, layout.FromBaseImage(testImage))
+						img, err := layout.NewImage(imagePath, layout.FromBaseImage(testImage), layout.WithMediaTypes(imgutil.OCITypes))
 						h.AssertNil(t, err)
 						h.AssertOCIMediaTypes(t, img)
 
@@ -199,7 +199,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := layout.NewImage(imagePath, layout.FromBaseImagePath(fullBaseImagePath))
 					h.AssertNil(t, err)
-					h.AssertOCIMediaTypes(t, img)
+					h.AssertDockerMediaTypes(t, img)
 
 					os, err := img.OS()
 					h.AssertNil(t, err)
@@ -225,7 +225,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					img, err := layout.NewImage(imagePath, layout.FromBaseImagePath(sparseBaseImagePath))
 					h.AssertNil(t, err)
-					h.AssertOCIMediaTypes(t, img)
+					h.AssertDockerMediaTypes(t, img)
 
 					os, err := img.OS()
 					h.AssertNil(t, err)

--- a/layout/new.go
+++ b/layout/new.go
@@ -59,10 +59,10 @@ func NewImage(path string, ops ...ImageOption) (*Image, error) {
 		ri.createdAt = imageOpts.createdAt
 	}
 
-	if imageOpts.mediaTypes == imgutil.MissingTypes && !hasBaseImage {
-		ri.requestedMediaTypes = imgutil.OCITypes
-	} else {
+	if imageOpts.mediaTypes != imgutil.MissingTypes {
 		ri.requestedMediaTypes = imageOpts.mediaTypes
+	} else if !hasBaseImage {
+		ri.requestedMediaTypes = imgutil.OCITypes
 	}
 	if err = ri.setUnderlyingImage(ri.Image); err != nil { // update media types
 		return nil, err

--- a/layout/new.go
+++ b/layout/new.go
@@ -42,6 +42,7 @@ func NewImage(path string, ops ...ImageOption) (*Image, error) {
 		}
 	}
 
+	hasBaseImage := imageOpts.baseImagePath != "" || imageOpts.baseImage != nil
 	if imageOpts.baseImagePath != "" {
 		if err := processBaseImageOption(ri, imageOpts.baseImagePath, platform); err != nil {
 			return nil, err
@@ -58,7 +59,7 @@ func NewImage(path string, ops ...ImageOption) (*Image, error) {
 		ri.createdAt = imageOpts.createdAt
 	}
 
-	if imageOpts.mediaTypes == imgutil.MissingTypes {
+	if imageOpts.mediaTypes == imgutil.MissingTypes && !hasBaseImage {
 		ri.requestedMediaTypes = imgutil.OCITypes
 	} else {
 		ri.requestedMediaTypes = imageOpts.mediaTypes

--- a/layout/sparse/sparse_test.go
+++ b/layout/sparse/sparse_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -133,9 +132,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				err = image.Save()
 				h.AssertNil(t, err)
 
-				actualMediaType, err := image.MediaType()
-				h.AssertNil(t, err)
-				h.AssertEq(t, actualMediaType, types.MediaType("application/vnd.oci.image.manifest.v1+json"))
+				h.AssertOCIMediaTypes(t, image)
 			})
 		})
 

--- a/layout/sparse/sparse_test.go
+++ b/layout/sparse/sparse_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
+	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/layout"
 	"github.com/buildpacks/imgutil/layout/sparse"
 	h "github.com/buildpacks/imgutil/testhelpers"
@@ -105,6 +107,52 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(index.Manifests), 1)
 				h.AssertEq(t, 1, len(index.Manifests[0].Annotations))
 				h.AssertEqAnnotation(t, index.Manifests[0], layout.ImageRefNameKey, "my-tag")
+			})
+		})
+
+		when("#MediaType", func() {
+			it("returns the base image media type when there are no requested media type changes", func() {
+				image, err := sparse.NewImage(imagePath, testImage)
+				h.AssertNil(t, err)
+
+				err = image.Save()
+				h.AssertNil(t, err)
+
+				expectedMediaType, err := testImage.MediaType()
+				h.AssertNil(t, err)
+
+				actualMediaType, err := image.MediaType()
+				h.AssertNil(t, err)
+				h.AssertEq(t, actualMediaType, expectedMediaType)
+			})
+
+			it("mutates the media type to the specified media type", func() {
+				image, err := sparse.NewImage(imagePath, testImage, layout.WithMediaTypes(imgutil.OCITypes))
+				h.AssertNil(t, err)
+
+				err = image.Save()
+				h.AssertNil(t, err)
+
+				actualMediaType, err := image.MediaType()
+				h.AssertNil(t, err)
+				h.AssertEq(t, actualMediaType, types.MediaType("application/vnd.oci.image.manifest.v1+json"))
+			})
+		})
+
+		when("#Digest", func() {
+			it("returns the original image digest when there are no modifications", func() {
+				image, err := sparse.NewImage(imagePath, testImage)
+				h.AssertNil(t, err)
+
+				err = image.Save()
+				h.AssertNil(t, err)
+
+				expectedDigest, err := testImage.Digest()
+				h.AssertNil(t, err)
+
+				actualDigest, err := image.Digest()
+				h.AssertNil(t, err)
+				h.AssertEq(t, actualDigest, expectedDigest)
 			})
 		})
 	})


### PR DESCRIPTION
The media type should only be modified when the user specifies it. In my case I noticed the digest given by the sparse.Image was not the same as the image it was dervied from. This was because the logic to set the media type defaulted to overriding to OCI if the media type was not specified. This commit changes the logic to only override the media type if the user specifies it.