### PR TITLE
Skip validating inspect ID after save

### DIFF
--- a/local/save.go
+++ b/local/save.go
@@ -116,7 +116,7 @@ func (i *Image) doSaveAs(name string) (types.ImageInspect, error) {
 	}()
 
 	tw := tar.NewWriter(pw)
-	configHash, err := i.addImageToTar(tw, repoName)
+	_, err = i.addImageToTar(tw, repoName)
 	if err != nil {
 		return types.ImageInspect{}, err
 	}

--- a/local/save.go
+++ b/local/save.go
@@ -136,9 +136,6 @@ func (i *Image) doSaveAs(name string) (types.ImageInspect, error) {
 		}
 		return types.ImageInspect{}, err
 	}
-	if err = i.validateInspect(inspect, configHash); err != nil {
-		return types.ImageInspect{}, err
-	}
 
 	return inspect, nil
 }
@@ -274,22 +271,6 @@ func (i *Image) addImageToTar(tw *tar.Writer, repoName string) (string, error) {
 	}
 
 	return configHash, addTextToTar(tw, "manifest.json", manifest)
-}
-
-func (i *Image) validateInspect(inspect types.ImageInspect, givenConfigHash string) error {
-	foundConfig, err := v1Config(inspect, i.createdAt, i.history)
-	if err != nil {
-		return fmt.Errorf("failed to get config file from inspect: %w", err)
-	}
-	foundConfigFile, err := json.Marshal(foundConfig)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config file: %w", err)
-	}
-	foundID := fmt.Sprintf("%x", sha256.Sum256(foundConfigFile))
-	if foundID != givenConfigHash {
-		return fmt.Errorf("expected config hash %q; got %q", givenConfigHash, foundID)
-	}
-	return nil
 }
 
 // helpers


### PR DESCRIPTION
Before #222, we calculated the sha of the config file that we sent to the daemon, and verified that we could inspect an image with that ID.

After #222, since the image ID may be the sha of the config file or the sha of the manifest file (depending on whether containerd storage is enabled), we still calculated the sha of the config file that we sent to the daemon, but instead of trying to inspect an image with that ID, we inspected the image by name, derived the config file from the data we got back from inspect, and then verified that the sha of the derived config file matches the sha of the config file that we sent in.

This check turned out to be brittle
(see https://github.com/buildpacks/pack/issues/2000 and https://cloud-native.slack.com/archives/C0331B61A1Y/p1701976103265489) and we agreed that it should be safe to remove this check.