### PR TITLE
Force the digest to be the same when saving sparse images

### DIFF
--- a/layout/layout.go
+++ b/layout/layout.go
@@ -15,6 +15,7 @@ type Image struct {
 	*imgutil.CNBImageCore
 	repoPath          string
 	saveWithoutLayers bool
+	preserveDigest    bool
 }
 
 func (i *Image) Kind() string {

--- a/layout/new.go
+++ b/layout/new.go
@@ -54,6 +54,7 @@ func NewImage(path string, ops ...ImageOption) (*Image, error) {
 		CNBImageCore:      cnbImage,
 		repoPath:          path,
 		saveWithoutLayers: options.WithoutLayers,
+		preserveDigest:    options.PreserveDigest,
 	}, nil
 }
 

--- a/layout/save.go
+++ b/layout/save.go
@@ -12,9 +12,12 @@ func (i *Image) Save(additionalNames ...string) error {
 
 // SaveAs ignores the image `Name()` method and saves the image according to name & additional names provided to this method
 func (i *Image) SaveAs(name string, additionalNames ...string) error {
-	if err := i.SetCreatedAtAndHistory(); err != nil {
-		return err
+	if !i.preserveDigest {
+		if err := i.SetCreatedAtAndHistory(); err != nil {
+			return err
+		}
 	}
+
 	refName, err := i.GetAnnotateRefName()
 	if err != nil {
 		return err

--- a/layout/sparse/new.go
+++ b/layout/sparse/new.go
@@ -3,14 +3,19 @@ package sparse
 import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
+	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/layout"
 )
 
 // NewImage returns a new Image saved on disk that can be modified
 func NewImage(path string, from v1.Image, ops ...layout.ImageOption) (*layout.Image, error) {
+	preserveDigest := func(opts *imgutil.ImageOptions) {
+		opts.PreserveDigest = true
+	}
 	ops = append([]layout.ImageOption{
 		layout.FromBaseImage(from),
 		layout.WithoutLayersWhenSaved(),
+		preserveDigest,
 	}, ops...)
 	img, err := layout.NewImage(path, ops...)
 	if err != nil {

--- a/layout/sparse/sparse_test.go
+++ b/layout/sparse/sparse_test.go
@@ -140,6 +140,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			it("returns the original image digest when there are no modifications", func() {
 				image, err := sparse.NewImage(imagePath, testImage)
 				h.AssertNil(t, err)
+				h.AssertNil(t, image.Save())
 
 				expectedDigest, err := testImage.Digest()
 				h.AssertNil(t, err)


### PR DESCRIPTION
A sparse image is always constructed "from" another image, and this package is typically used to save "base" images (build or run) from the registry or wherever to disk.
In such scenarios, it is surprising for the digest to mutate when saving. In a sense, sparse images do not really need to be imgutil.Images at all, they just need to be v1.Images.

However for other local/remote/layout packages,
we typically want to zero out timestamps
in order to fulfill the reproducibility expectations of CNB, so preserving the digest when saving is not the default behavior.