### PR TITLE
Fix locallayout package, make it suitable to replace the local package

### DIFF
--- a/locallayout/new.go
+++ b/locallayout/new.go
@@ -3,7 +3,6 @@ package locallayout
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
@@ -48,7 +47,7 @@ func NewImage(repoName string, dockerClient DockerClient, ops ...func(*imgutil.I
 		baseIdentifier = processBase.identifier
 		store = processBase.layerStore
 	} else {
-		store = &Store{dockerClient: dockerClient, downloadOnce: &sync.Once{}}
+		store = NewStore(dockerClient)
 	}
 
 	cnbImage, err := imgutil.NewCNBImage(*options)
@@ -108,7 +107,7 @@ func processImageOption(repoName string, dockerClient DockerClient, downloadLaye
 	if inspect == nil {
 		return imageResult{}, nil
 	}
-	layerStore := &Store{dockerClient: dockerClient, downloadOnce: &sync.Once{}}
+	layerStore := NewStore(dockerClient)
 	image, err := newV1ImageFacadeFromInspect(*inspect, history, layerStore, downloadLayersOnAccess)
 	if err != nil {
 		return imageResult{}, err


### PR DESCRIPTION
https://github.com/buildpacks/imgutil/pull/238 introduced a locallayout package with the idea that we would eventually use this package to send an OCI layout-formatted tar to the daemon instead of a legacy tar.

However, as described in https://github.com/buildpacks/imgutil/pull/242#issuecomment-1927692207 this isn't a viable approach for the time being.

This PR updates the locallayout package to remove the noted inefficiency and add support for containerd storage, so that locallayout can replace the local package. This will allow us to simplify our code because local images will be v1 Images. 