### PR TITLE
Add back remote.ImageOption

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -5,7 +5,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - dogsled
     - exportloopref
     - gocritic
@@ -18,12 +17,10 @@ linters:
     - nakedret
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:

--- a/remote/options.go
+++ b/remote/options.go
@@ -8,10 +8,12 @@ import (
 	"github.com/buildpacks/imgutil"
 )
 
+type ImageOption func(o *imgutil.ImageOptions)
+
 // AddEmptyLayerOnSave adds an empty layer before saving if the image has no layers at all.
 // This option is useful when exporting to registries that do not allow saving an image without layers,
 // for example: gcr.io.
-func AddEmptyLayerOnSave() func(*imgutil.ImageOptions) {
+func AddEmptyLayerOnSave() ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.AddEmptyLayerOnSave = true
 	}
@@ -19,14 +21,14 @@ func AddEmptyLayerOnSave() func(*imgutil.ImageOptions) {
 
 // FromBaseImage loads the provided image as the manifest, config, and layers for the working image.
 // If the image is not found, it does nothing.
-func FromBaseImage(name string) func(*imgutil.ImageOptions) {
+func FromBaseImage(name string) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.BaseImageRepoName = name
 	}
 }
 
 // WithConfig lets a caller provided a `config` object for the working image.
-func WithConfig(c *v1.Config) func(*imgutil.ImageOptions) {
+func WithConfig(c *v1.Config) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.Config = c
 	}
@@ -34,7 +36,7 @@ func WithConfig(c *v1.Config) func(*imgutil.ImageOptions) {
 
 // WithCreatedAt lets a caller set the "created at" timestamp for the working image when saved.
 // If not provided, the default is imgutil.NormalizedDateTime.
-func WithCreatedAt(t time.Time) func(*imgutil.ImageOptions) {
+func WithCreatedAt(t time.Time) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.CreatedAt = t
 	}
@@ -42,7 +44,7 @@ func WithCreatedAt(t time.Time) func(*imgutil.ImageOptions) {
 
 // WithDefaultPlatform provides the default Architecture/OS/OSVersion if no base image is provided,
 // or if the provided image inputs (base and previous) are manifest lists.
-func WithDefaultPlatform(p imgutil.Platform) func(*imgutil.ImageOptions) {
+func WithDefaultPlatform(p imgutil.Platform) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.Platform = p
 	}
@@ -50,7 +52,7 @@ func WithDefaultPlatform(p imgutil.Platform) func(*imgutil.ImageOptions) {
 
 // WithHistory if provided will configure the image to preserve history when saved
 // (including any history from the base image if valid).
-func WithHistory() func(*imgutil.ImageOptions) {
+func WithHistory() ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.PreserveHistory = true
 	}
@@ -58,7 +60,7 @@ func WithHistory() func(*imgutil.ImageOptions) {
 
 // WithMediaTypes lets a caller set the desired media types for the manifest and config (including layers referenced in the manifest)
 // to be either OCI media types or Docker media types.
-func WithMediaTypes(m imgutil.MediaTypes) func(*imgutil.ImageOptions) {
+func WithMediaTypes(m imgutil.MediaTypes) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.MediaTypes = m
 	}
@@ -67,7 +69,7 @@ func WithMediaTypes(m imgutil.MediaTypes) func(*imgutil.ImageOptions) {
 // WithPreviousImage loads an existing image as the source for reusable layers.
 // Use with ReuseLayer().
 // If the image is not found, it does nothing.
-func WithPreviousImage(name string) func(*imgutil.ImageOptions) {
+func WithPreviousImage(name string) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		o.PreviousImageRepoName = name
 	}
@@ -78,7 +80,7 @@ func WithPreviousImage(name string) func(*imgutil.ImageOptions) {
 // in order to construct the image.
 // The referenced images could include the base image, a previous image, or the image itself.
 // The insecure parameter allows image references to be fetched without TLS.
-func WithRegistrySetting(repository string, insecure bool) func(*imgutil.ImageOptions) {
+func WithRegistrySetting(repository string, insecure bool) ImageOption {
 	return func(o *imgutil.ImageOptions) {
 		if o.RegistrySettings == nil {
 			o.RegistrySettings = make(map[string]imgutil.RegistrySetting)


### PR DESCRIPTION
https://github.com/buildpacks/imgutil/pull/257 inadvertently removed this type definition 

Also removes unused (abandoned) linters