### PR TITLE
Add custom error type for layer not found

### DIFF
--- a/cnb_image.go
+++ b/cnb_image.go
@@ -82,6 +82,17 @@ func (i *CNBImageCore) GetAnnotateRefName() (string, error) {
 }
 
 func (i *CNBImageCore) GetLayer(diffID string) (io.ReadCloser, error) {
+	layerHash, err := v1.NewHash(diffID)
+	if err != nil {
+		return nil, err
+	}
+	configFile, err := i.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	if !contains(configFile.RootFS.DiffIDs, layerHash) {
+		return nil, ErrLayerNotFound{DiffID: layerHash.String()}
+	}
 	hash, err := v1.NewHash(diffID)
 	if err != nil {
 		return nil, err
@@ -91,6 +102,15 @@ func (i *CNBImageCore) GetLayer(diffID string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	return layer.Uncompressed()
+}
+
+func contains(diffIDs []v1.Hash, hash v1.Hash) bool {
+	for _, diffID := range diffIDs {
+		if diffID.String() == hash.String() {
+			return true
+		}
+	}
+	return false
 }
 
 // TBD Deprecated: History

--- a/image.go
+++ b/image.go
@@ -100,3 +100,11 @@ func (e SaveError) Error() string {
 	}
 	return fmt.Sprintf("failed to write image to the following tags: %s", strings.Join(errors, ","))
 }
+
+type ErrLayerNotFound struct {
+	DiffID string
+}
+
+func (e ErrLayerNotFound) Error() string {
+	return fmt.Sprintf("failed to find layer with diff ID %q", e.DiffID)
+}

--- a/local/local.go
+++ b/local/local.go
@@ -53,6 +53,13 @@ func (i *Image) GetLayer(diffID string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+	configFile, err := i.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	if !contains(configFile.RootFS.DiffIDs, layerHash) {
+		return nil, imgutil.ErrLayerNotFound{DiffID: layerHash.String()}
+	}
 	layer, err := i.LayerByDiffID(layerHash)
 	if err == nil {
 		// this avoids downloading ALL the image layers from the daemon
@@ -61,13 +68,6 @@ func (i *Image) GetLayer(diffID string) (io.ReadCloser, error) {
 		if size, err := layer.Size(); err != nil && size != -1 {
 			return layer.Uncompressed()
 		}
-	}
-	configFile, err := i.ConfigFile()
-	if err != nil {
-		return nil, err
-	}
-	if !contains(configFile.RootFS.DiffIDs, layerHash) {
-		return nil, fmt.Errorf("image %q does not contain layer with diff ID %q", i.Name(), layerHash.String())
 	}
 	if err = i.ensureLayers(); err != nil {
 		return nil, err

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1584,11 +1584,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					h.AssertNil(t, err)
 					_, err = img.GetLayer(someSHA)
-					h.AssertError(
-						t,
-						err,
-						fmt.Sprintf(`image %q does not contain layer with diff ID "%s"`, repoName, someSHA),
-					)
+					h.AssertError(t, err, fmt.Sprintf("failed to find layer with diff ID %q", someSHA))
+					_, ok := err.(imgutil.ErrLayerNotFound)
+					h.AssertEq(t, ok, true)
 				})
 			})
 		})
@@ -1600,7 +1598,9 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				readCloser, err := image.GetLayer(someSHA)
 				h.AssertNil(t, readCloser)
-				h.AssertError(t, err, fmt.Sprintf("image %q does not contain layer with diff ID %q", "not-exist", someSHA))
+				h.AssertError(t, err, fmt.Sprintf("failed to find layer with diff ID %q", someSHA))
+				_, ok := err.(imgutil.ErrLayerNotFound)
+				h.AssertEq(t, ok, true)
 			})
 		})
 	})


### PR DESCRIPTION
This avoids the need for the lifecycle to do some brittle string checking