### PR TITLE
Ensure we always normalize history before saving

### DIFF
--- a/cnb_image.go
+++ b/cnb_image.go
@@ -535,6 +535,7 @@ func (i *CNBImageCore) SetCreatedAtAndHistory() error {
 	if i.preserveHistory {
 		// set created at for each history
 		err = i.MutateConfigFile(func(c *v1.ConfigFile) {
+			c.History = NormalizedHistory(c.History, len(c.RootFS.DiffIDs))
 			for j := range c.History {
 				c.History[j].Created = v1.Time{Time: i.createdAt}
 			}
@@ -542,6 +543,7 @@ func (i *CNBImageCore) SetCreatedAtAndHistory() error {
 	} else {
 		// zero history
 		err = i.MutateConfigFile(func(c *v1.ConfigFile) {
+			c.History = NormalizedHistory(c.History, len(c.RootFS.DiffIDs))
 			for j := range c.History {
 				c.History[j] = v1.History{Created: v1.Time{Time: i.createdAt}}
 			}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1273,6 +1273,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				newBaseImg, err := remote.NewImage(newBase, authn.DefaultKeychain, remote.FromBaseImage(newBase))
 				h.AssertNil(t, err)
 
+				h.AssertNil(t, newBaseImg.MutateConfigFile(func(c *v1.ConfigFile) {
+					c.History = []v1.History{
+						{CreatedBy: "/new-base.txt"},
+						{CreatedBy: "FOOBAR", EmptyLayer: true}, // add empty layer history
+						{CreatedBy: "/otherfile.txt"},
+					}
+				})) // don't save the image, as that will strip the empty layer history
+
 				err = img.Rebase(oldTopLayerDiffID, newBaseImg)
 				h.AssertNil(t, err)
 				h.AssertNil(t, img.Save())
@@ -1288,6 +1296,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, rebasedImgConfig.OS, newBaseConfig.OS)
 				h.AssertEq(t, rebasedImgConfig.OSVersion, newBaseConfig.OSVersion)
 				h.AssertEq(t, rebasedImgConfig.Architecture, newBaseConfig.Architecture)
+				h.AssertEq(t, len(rebasedImgConfig.History), len(rebasedImgConfig.RootFS.DiffIDs))
 			})
 		})
 	})


### PR DESCRIPTION
Previously, we normalized history whenever layers were added (either via AddLayer or ReuseLayer),
but when rebasing, if the new base image has empty layer history the information about the empty/non-empty aspect of the history will be lost if "preserve history" isn't set on the image.