### PR TITLE
Adding missing variant attribute in our Platform definition

### DIFF
--- a/image.go
+++ b/image.go
@@ -108,10 +108,11 @@ type WithEditableLayers interface {
 
 type Identifier fmt.Stringer
 
-// Platform represents the target arch/os/os_version for an image construction and querying.
+// Platform represents the target arch/os/variant/os_version for an image construction and querying.
 type Platform struct {
 	Architecture string
 	OS           string
+	Variant      string
 	OSVersion    string
 }
 

--- a/layout/layout_test.go
+++ b/layout/layout_test.go
@@ -93,6 +93,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					layout.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "windows",
+						Variant:      "v1",
 						OSVersion:    "10.0.17763.316",
 					}),
 				)
@@ -108,6 +109,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				h.AssertEq(t, os, "windows")
 
+				variant, err := img.Variant()
+				h.AssertNil(t, err)
+				h.AssertEq(t, variant, "v1")
+
 				osVersion, err := img.OSVersion()
 				h.AssertNil(t, err)
 				h.AssertEq(t, osVersion, "10.0.17763.316")
@@ -122,6 +127,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					layout.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "linux",
+						Variant:      "v6",
+						OSVersion:    "21.01",
 					}),
 				)
 				h.AssertNil(t, err)
@@ -135,6 +142,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				os, err := img.OS()
 				h.AssertNil(t, err)
 				h.AssertEq(t, os, "linux")
+
+				variant, err := img.Variant()
+				h.AssertNil(t, err)
+				h.AssertEq(t, variant, "v6")
+
+				osVersion, err := img.OSVersion()
+				h.AssertNil(t, err)
+				h.AssertEq(t, osVersion, "21.01")
 
 				_, err = img.TopLayer()
 				h.AssertError(t, err, "has no layers")

--- a/layout/new.go
+++ b/layout/new.go
@@ -110,7 +110,9 @@ func imageFromIndex(index v1.ImageIndex, platform imgutil.Platform) (v1.Image, e
 	} else {
 		for _, m := range manifestList.Manifests {
 			if m.Platform.OS == platform.OS &&
-				m.Platform.Architecture == platform.Architecture {
+				m.Platform.Architecture == platform.Architecture &&
+				m.Platform.Variant == platform.Variant &&
+				m.Platform.OSVersion == platform.OSVersion {
 				manifest = m
 				break
 			}

--- a/new.go
+++ b/new.go
@@ -119,6 +119,7 @@ func emptyV1(withPlatform Platform, withMediaTypes MediaTypes) (v1.Image, error)
 		History:      []v1.History{},
 		OS:           withPlatform.OS,
 		OSVersion:    withPlatform.OSVersion,
+		Variant:      withPlatform.Variant,
 		RootFS: v1.RootFS{
 			Type:    "layers",
 			DiffIDs: []v1.Hash{},

--- a/remote/new.go
+++ b/remote/new.go
@@ -82,6 +82,7 @@ func processImageOption(repoName string, keychain authn.Keychain, withPlatform i
 	platform := v1.Platform{
 		Architecture: withPlatform.Architecture,
 		OS:           withPlatform.OS,
+		Variant:      withPlatform.Variant,
 		OSVersion:    withPlatform.OSVersion,
 	}
 	reg := getRegistrySetting(repoName, withRegistrySettings)
@@ -153,6 +154,7 @@ func emptyImage(platform imgutil.Platform) (v1.Image, error) {
 		Architecture: platform.Architecture,
 		History:      []v1.History{},
 		OS:           platform.OS,
+		Variant:      platform.Variant,
 		OSVersion:    platform.OSVersion,
 		RootFS: v1.RootFS{
 			Type:    "layers",

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -123,6 +123,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					remote.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "windows",
+						Variant:      "v1",
 						OSVersion:    "10.0.17763.316",
 					}),
 				)
@@ -136,6 +137,10 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				os, err := img.OS()
 				h.AssertNil(t, err)
 				h.AssertEq(t, os, "windows")
+
+				variant, err := img.Variant()
+				h.AssertNil(t, err)
+				h.AssertEq(t, variant, "v1")
 
 				osVersion, err := img.OSVersion()
 				h.AssertNil(t, err)
@@ -155,6 +160,8 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					remote.WithDefaultPlatform(imgutil.Platform{
 						Architecture: "arm",
 						OS:           "linux",
+						Variant:      "v6",
+						OSVersion:    "21.01",
 					}),
 				)
 				h.AssertNil(t, err)
@@ -167,6 +174,14 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				osName, err := img.OS()
 				h.AssertNil(t, err)
 				h.AssertEq(t, osName, "linux")
+
+				variant, err := img.Variant()
+				h.AssertNil(t, err)
+				h.AssertEq(t, variant, "v6")
+
+				osVersion, err := img.OSVersion()
+				h.AssertNil(t, err)
+				h.AssertEq(t, osVersion, "21.01")
 
 				_, err = img.TopLayer()
 				h.AssertError(t, err, "has no layers")


### PR DESCRIPTION
Now that we are processing multi-platform images, is important to match all the Platform attributes in a [Image Index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)

This PR is adding the missing *variant* attribute, we used to have `os`, `arch`, `osVersion` but `variant` was missing