### PR TITLE
Fix: `archive/tar: write too long` error when using Docker Desktop containerd backend

### DIFF
--- a/local/v1_facade.go
+++ b/local/v1_facade.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -230,22 +229,6 @@ func newDownloadableEmptyLayer(diffID v1.Hash, store *Store, imageID string) *v1
 				return layer.Size()
 			}
 			return -1, nil
-		},
-	}
-}
-
-func newPopulatedLayer(diffID v1.Hash, fromPath string, uncompressedSize int64) *v1LayerFacade {
-	return &v1LayerFacade{
-		diffID: diffID,
-		uncompressed: func() (io.ReadCloser, error) {
-			f, err := os.Open(fromPath)
-			if err != nil {
-				return nil, err
-			}
-			return f, nil
-		},
-		uncompressedSize: func() (int64, error) {
-			return uncompressedSize, nil
 		},
 	}
 }


### PR DESCRIPTION
Fixes (in part) https://github.com/buildpacks/pack/issues/2174

This is somewhat of a band-aid solution and degrades performance because we have to read the uncompressed layer bits to get the uncompressed layer size for layers that we `docker save` out of the daemon (re-used layers and all the base layers).

The better longer-term fix will be to send OCI-layout formatted tars when we have all the layers available (when using containerd as the backing store, this will always be true).