### PR TITLE
Fix: imgutil/local: Add a warning message when saving a local image and containerd storage is enable #284

### DIFF
--- a/local/new.go
+++ b/local/new.go
@@ -47,7 +47,11 @@ func NewImage(repoName string, dockerClient DockerClient, ops ...imgutil.ImageOp
 		baseIdentifier = baseImage.identifier
 		store = baseImage.layerStore
 	} else {
-		store = NewStore(dockerClient)
+		if options.Logger != nil {
+			store = NewStore(dockerClient, WithStoreLogger(options.Logger))
+		} else {
+			store = NewStore(dockerClient)
+		}
 	}
 
 	cnbImage, err := imgutil.NewCNBImage(*options)

--- a/local/options.go
+++ b/local/options.go
@@ -38,3 +38,15 @@ func WithMediaTypes(m imgutil.MediaTypes) func(*imgutil.ImageOptions) {
 func WithPreviousImage(name string) func(*imgutil.ImageOptions) {
 	return imgutil.WithPreviousImage(name)
 }
+
+func WithLogger(logger imgutil.Logger) func(*imgutil.ImageOptions) {
+	return imgutil.WithLogger(logger)
+}
+
+type StoreOption func(*Store)
+
+func WithStoreLogger(logger imgutil.Logger) StoreOption {
+	return func(s *Store) {
+		s.Logger = logger
+	}
+}

--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ type ImageOptions struct {
 	BaseImageRepoName     string
 	PreviousImageRepoName string
 	Config                *v1.Config
+	Logger                Logger
 	CreatedAt             time.Time
 	MediaTypes            MediaTypes
 	Platform              Platform
@@ -41,6 +42,10 @@ type RemoteOptions struct {
 
 type RegistrySetting struct {
 	Insecure bool
+}
+
+type Logger interface {
+	Warn(msg string)
 }
 
 // FromBaseImage loads the provided image as the manifest, config, and layers for the working image.
@@ -96,6 +101,13 @@ func WithMediaTypes(m MediaTypes) func(*ImageOptions) {
 func WithPreviousImage(name string) func(*ImageOptions) {
 	return func(o *ImageOptions) {
 		o.PreviousImageRepoName = name
+	}
+}
+
+// WithLogger if provided will check if contained is used.
+func WithLogger(logger Logger) func(*ImageOptions) {
+	return func(o *ImageOptions) {
+		o.Logger = logger
 	}
 }
 


### PR DESCRIPTION
Fixse (imgutil) https://github.com/buildpacks/imgutil/issues/282

This pr enhances the Logger functionality by integrating it with the existing
automatic detection of the storage driver type in the NewStore function.
The Logger interface has been added to log warnings related to the containerd storage driver.
Test cases have been created to ensure that warnings are logged correctly when using containerd.