### PR TITLE
chore: Bump github.com/docker/docker to v28.0.4 and fix broken API

### DIFF
--- a/acceptance/reproducibility_test.go
+++ b/acceptance/reproducibility_test.go
@@ -48,7 +48,7 @@ func testReproducibility(t *testing.T, _ spec.G, it spec.S) {
 		imageName1, imageName2 string
 		layer1, layer2         string
 		mutateAndSave          func(t *testing.T, image imgutil.Image)
-		dockerClient           dockerclient.CommonAPIClient
+		dockerClient           dockerclient.APIClient
 		runnableBaseImageName  string
 	)
 

--- a/fakes/image_index.go
+++ b/fakes/image_index.go
@@ -1,9 +1,10 @@
 package fakes
 
 import (
-	"github.com/buildpacks/imgutil"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/buildpacks/imgutil"
 )
 
 var _ imgutil.ImageIndex = ImageIndex{}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/buildpacks/imgutil
 
 require (
-	github.com/docker/docker v26.0.1+incompatible
+	github.com/docker/docker v26.0.1+incompatible //upgrade
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/buildpacks/imgutil
 
 require (
-	github.com/docker/docker v26.0.1+incompatible //upgrade
+	github.com/docker/docker v28.0.4+incompatible //upgrade
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/pkg/errors v0.9.1
@@ -15,7 +15,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/cli v24.0.2+incompatible // indirect
+	github.com/docker/cli v28.0.4+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,14 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v24.0.2+incompatible h1:QdqR7znue1mtkXIJ+ruQMGQhpw2JzMJLRXp6zpzF6tM=
 github.com/docker/cli v24.0.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.0.4+incompatible h1:pBJSJeNd9QeIWPjRcV91RVJihd/TXB77q1ef64XEu4A=
+github.com/docker/cli v28.0.4+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v26.0.1+incompatible h1:t39Hm6lpXuXtgkF0dm1t9a5HkbUfdGy6XbWexmGr+hA=
 github.com/docker/docker v26.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.4+incompatible h1:JNNkBctYKurkw6FrHfKqY0nKIDf5nrbxjVBtS+cdcok=
+github.com/docker/docker v28.0.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -77,7 +77,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					err = h.DockerRmi(dockerClient, img.Name())
 					h.AssertNil(t, err)
 				}()
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+				inspect, err := dockerClient.ImageInspect(context.TODO(), img.Name())
 				h.AssertNil(t, err)
 
 				daemonInfo, err := dockerClient.ServerVersion(context.TODO())
@@ -115,7 +115,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					err = h.DockerRmi(dockerClient, img.Name())
 					h.AssertNil(t, err)
 				}()
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+				inspect, err := dockerClient.ImageInspect(context.TODO(), img.Name())
 				h.AssertNil(t, err)
 
 				daemonInfo, err := dockerClient.Info(context.TODO())
@@ -208,7 +208,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, err)
 						h.AssertEq(t, imgOS, daemonOS)
 
-						inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+						inspect, err := dockerClient.ImageInspect(context.TODO(), img.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, inspect.Os, daemonOS)
 						h.AssertEq(t, inspect.Architecture, daemonArchitecture)
@@ -308,7 +308,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, img.Save())
 						defer h.DockerRmi(dockerClient, img.Name())
 
-						inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+						inspect, err := dockerClient.ImageInspect(context.TODO(), img.Name())
 						h.AssertNil(t, err)
 
 						daemonInfo, err := dockerClient.Info(context.TODO())
@@ -752,7 +752,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			id, err := img.Identifier()
 			h.AssertNil(t, err)
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), id.String())
+			inspect, err := dockerClient.ImageInspect(context.TODO(), id.String())
 			h.AssertNil(t, err)
 			labelValue := inspect.Config.Labels["existingLabel"]
 			h.AssertEq(t, labelValue, "existingValue")
@@ -775,7 +775,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				id, err := img.Identifier()
 				h.AssertNil(t, err)
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), id.String())
+				inspect, err := dockerClient.ImageInspect(context.TODO(), id.String())
 				h.AssertNil(t, err)
 
 				label := inspect.Config.Labels["new"]
@@ -824,7 +824,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 				label = inspect.Config.Labels["somekey"]
 				h.AssertEq(t, strings.TrimSpace(label), "new-val")
@@ -851,7 +851,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				label = inspect.Config.Labels["somekey"]
@@ -906,7 +906,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.RemoveLabel("my.custom.label"))
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 				_, exists := inspect.Config.Labels["my.custom.label"]
 				h.AssertEq(t, exists, false)
@@ -933,7 +933,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertContains(t, inspect.Config.Env, "ENV_KEY=ENV_VAL")
@@ -952,7 +952,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				h.AssertContains(t, inspect.Config.Env, "ENV_KEY=SOME_OTHER_VAL")
@@ -983,7 +983,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					h.AssertNil(t, img.Save())
 
-					inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+					inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 					h.AssertNil(t, err)
 
 					h.AssertContains(t, inspect.Config.Env, "env_key=SOME_OTHER_VAL")
@@ -1014,7 +1014,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, inspect.Config.WorkingDir, "/some/work/dir")
@@ -1037,7 +1037,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, []string(inspect.Config.Entrypoint), []string{"some", "entrypoint"})
@@ -1060,7 +1060,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, []string(inspect.Config.Cmd), []string{"some", "cmd"})
@@ -1086,7 +1086,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, inspect.Os, daemonOS)
@@ -1112,7 +1112,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, inspect.OsVersion, "1.2.3.4")
@@ -1179,7 +1179,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, oldBaseImage.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), oldBase)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), oldBase)
 				h.AssertNil(t, err)
 				oldTopLayer = h.StringElementAt(inspect.RootFS.Layers, -1)
 
@@ -1215,7 +1215,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			it("switches the base", func() {
 				// Before
-				beforeInspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				beforeInspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				beforeOldBaseLayer1DiffID := h.StringElementAt(beforeInspect.RootFS.Layers, -4)
@@ -1241,7 +1241,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 
 				// After
-				afterInspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				afterInspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				numLayers := len(afterInspect.RootFS.Layers)
@@ -1290,7 +1290,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, existingImage.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 				expectedTopLayer = h.StringElementAt(inspect.RootFS.Layers, -1)
 			})
@@ -1346,7 +1346,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 				defer h.DockerRmi(dockerClient, repoName)
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, newLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -1))
@@ -1396,7 +1396,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, img.Save())
 				defer h.DockerRmi(dockerClient, repoName)
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, oldLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -2))
@@ -1445,7 +1445,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, img.Save())
 			defer h.DockerRmi(dockerClient, repoName)
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, oldLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -2))
@@ -1516,7 +1516,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			lastHistory := daemonReportsHistory[0] // the daemon reports history in reverse order
 			h.AssertEq(t, lastHistory.CreatedBy, "some-history")
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			h.AssertEq(t, oldLayerDiffID, h.StringElementAt(inspect.RootFS.Layers, -2))
@@ -1637,7 +1637,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, prevImage.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), prevImageName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), prevImageName)
 			h.AssertNil(t, err)
 
 			prevLayer1SHA = h.StringElementAt(inspect.RootFS.Layers, -2)
@@ -1670,7 +1670,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			newLayer1SHA := h.StringElementAt(inspect.RootFS.Layers, -2)
@@ -1695,7 +1695,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			if daemonOS == "windows" {
@@ -1753,7 +1753,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				newLayer1SHA := h.StringElementAt(inspect.RootFS.Layers, -2)
@@ -1804,7 +1804,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, prevImage.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), prevImageName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), prevImageName)
 			h.AssertNil(t, err)
 
 			prevLayer1SHA = h.StringElementAt(inspect.RootFS.Layers, -2)
@@ -1836,7 +1836,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 			h.AssertNil(t, img.Save())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+			inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 			h.AssertNil(t, err)
 
 			newLayer1SHA := h.StringElementAt(inspect.RootFS.Layers, -2)
@@ -1901,7 +1901,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 				newImageID := h.ImageID(t, repoName)
 				h.AssertNotEq(t, origID, newImageID)
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), identifier.String())
+				inspect, err := dockerClient.ImageInspect(context.TODO(), identifier.String())
 				h.AssertNil(t, err)
 				label := inspect.Config.Labels["mykey"]
 				h.AssertEq(t, strings.TrimSpace(label), "newValue")
@@ -1916,7 +1916,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, img.Save())
 
-				inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, inspect.Created, imgutil.NormalizedDateTime.Format(time.RFC3339))
@@ -1946,7 +1946,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 					h.AssertNil(t, img.Save())
 
-					inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+					inspect, err := dockerClient.ImageInspect(context.TODO(), repoName)
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, inspect.Created, expectedTime.Format(time.RFC3339))
@@ -1979,7 +1979,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, img.Save(additionalRepoNames...))
 
 					for _, n := range successfulRepoNames {
-						_, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), n)
+						_, err := dockerClient.ImageInspect(context.TODO(), n)
 						h.AssertNil(t, err)
 					}
 				})
@@ -2060,7 +2060,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			f.Close()
 			defer h.DockerRmi(dockerClient, img.Name())
 
-			inspect, _, err := dockerClient.ImageInspectWithRaw(context.TODO(), img.Name())
+			inspect, err := dockerClient.ImageInspect(context.TODO(), img.Name())
 			h.AssertNil(t, err)
 
 			for _, diffID := range inspect.RootFS.Layers {

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -41,7 +41,7 @@ func newTestImageName() string {
 
 func testImage(t *testing.T, when spec.G, it spec.S) {
 	var (
-		dockerClient          client.CommonAPIClient
+		dockerClient          client.APIClient
 		daemonOS              string
 		daemonArchitecture    string
 		runnableBaseImageName string

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -1204,7 +1204,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 
 				h.AssertNil(t, origImage.Save())
 
-				inspect, _, err = dockerClient.ImageInspectWithRaw(context.TODO(), repoName)
+				inspect, err = dockerClient.ImageInspect(context.TODO(), repoName)
 				h.AssertNil(t, err)
 				origNumLayers = len(inspect.RootFS.Layers)
 			})
@@ -1998,7 +1998,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, saveErr.Errors[0].Cause, "invalid reference format")
 
 						for _, n := range successfulRepoNames {
-							_, _, err = dockerClient.ImageInspectWithRaw(context.TODO(), n)
+							_, err = dockerClient.ImageInspect(context.TODO(), n)
 							h.AssertNil(t, err)
 						}
 					})

--- a/local/local_test.go
+++ b/local/local_test.go
@@ -2055,7 +2055,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, err)
 			defer f.Close()
 
-			_, err = dockerClient.ImageLoad(context.TODO(), f, true)
+			_, err = dockerClient.ImageLoad(context.TODO(), f, client.ImageLoadWithQuiet(true))
 			h.AssertNil(t, err)
 			f.Close()
 			defer h.DockerRmi(dockerClient, img.Name())

--- a/local/new.go
+++ b/local/new.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -119,7 +118,7 @@ func processImageOption(repoName string, dockerClient DockerClient, downloadLaye
 	}, nil
 }
 
-func getInspectAndHistory(repoName string, dockerClient DockerClient) (*types.ImageInspect, []image.HistoryResponseItem, error) {
+func getInspectAndHistory(repoName string, dockerClient DockerClient) (*image.InspectResponse, []image.HistoryResponseItem, error) {
 	inspect, err := dockerClient.ImageInspect(context.Background(), repoName)
 	if err != nil {
 		if client.IsErrNotFound(err) {

--- a/local/new.go
+++ b/local/new.go
@@ -120,7 +120,7 @@ func processImageOption(repoName string, dockerClient DockerClient, downloadLaye
 }
 
 func getInspectAndHistory(repoName string, dockerClient DockerClient) (*types.ImageInspect, []image.HistoryResponseItem, error) {
-	inspect, _, err := dockerClient.ImageInspectWithRaw(context.Background(), repoName)
+	inspect, err := dockerClient.ImageInspect(context.Background(), repoName)
 	if err != nil {
 		if client.IsErrNotFound(err) {
 			return nil, nil, nil

--- a/local/store.go
+++ b/local/store.go
@@ -42,7 +42,7 @@ type DockerClient interface {
 	ImageInspect(ctx context.Context, image string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
 	ImageLoad(ctx context.Context, input io.Reader, opts ...client.ImageLoadOption) (image.LoadResponse, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
-	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
+	ImageSave(ctx context.Context, images []string, opts ...client.ImageSaveOption) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
 	Info(ctx context.Context) (system.Info, error)
 	ServerVersion(ctx context.Context) (types.Version, error)

--- a/local/store.go
+++ b/local/store.go
@@ -36,7 +36,7 @@ type Store struct {
 	onDiskLayersByDiffID map[v1.Hash]annotatedLayer
 }
 
-// DockerClient is subset of client.CommonAPIClient required by this package.
+// DockerClient is subset of client.APIClient required by this package.
 type DockerClient interface {
 	ImageHistory(ctx context.Context, image string, opts ...client.ImageHistoryOption) ([]image.HistoryResponseItem, error)
 	ImageInspect(ctx context.Context, image string, opts ...client.ImageInspectOption) (image.InspectResponse, error)

--- a/local/store.go
+++ b/local/store.go
@@ -38,9 +38,9 @@ type Store struct {
 
 // DockerClient is subset of client.CommonAPIClient required by this package.
 type DockerClient interface {
-	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)
-	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)
-	ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error)
+	ImageHistory(ctx context.Context, image string, opts ...client.ImageHistoryOption) ([]image.HistoryResponseItem, error)
+	ImageInspect(ctx context.Context, image string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
+	ImageLoad(ctx context.Context, input io.Reader, opts ...client.ImageLoadOption) (image.LoadResponse, error)
 	ImageRemove(ctx context.Context, image string, options image.RemoveOptions) ([]image.DeleteResponse, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
@@ -64,7 +64,7 @@ func NewStore(dockerClient DockerClient) *Store {
 // images
 
 func (s *Store) Contains(identifier string) bool {
-	_, _, err := s.dockerClient.ImageInspectWithRaw(context.Background(), identifier)
+	_, err := s.dockerClient.ImageInspect(context.Background(), identifier)
 	return err == nil
 }
 
@@ -146,7 +146,7 @@ func usesContainerdStorage(docker DockerClient) bool {
 	return false
 }
 
-func (s *Store) doSave(image v1.Image, withName string) (types.ImageInspect, error) {
+func (s *Store) doSave(img v1.Image, withName string) (types.ImageInspect, error) {
 	ctx := context.Background()
 	done := make(chan error)
 
@@ -155,8 +155,8 @@ func (s *Store) doSave(image v1.Image, withName string) (types.ImageInspect, err
 	defer pw.Close()
 
 	go func() {
-		var res types.ImageLoadResponse
-		res, err = s.dockerClient.ImageLoad(ctx, pr, true)
+		var res image.LoadResponse
+		res, err = s.dockerClient.ImageLoad(ctx, pr, client.ImageLoadWithQuiet(true))
 		if err != nil {
 			done <- err
 			return
@@ -179,7 +179,7 @@ func (s *Store) doSave(image v1.Image, withName string) (types.ImageInspect, err
 	tw := tar.NewWriter(pw)
 	defer tw.Close()
 
-	if err = s.addImageToTar(tw, image, withName); err != nil {
+	if err = s.addImageToTar(tw, img, withName); err != nil {
 		return types.ImageInspect{}, err
 	}
 	tw.Close()
@@ -189,7 +189,7 @@ func (s *Store) doSave(image v1.Image, withName string) (types.ImageInspect, err
 		return types.ImageInspect{}, fmt.Errorf("loading image %q. first error: %w", withName, err)
 	}
 
-	inspect, _, err := s.dockerClient.ImageInspectWithRaw(context.Background(), withName)
+	inspect, err := s.dockerClient.ImageInspect(context.Background(), withName)
 	if err != nil {
 		if client.IsErrNotFound(err) {
 			return types.ImageInspect{}, fmt.Errorf("saving image %q: %w", withName, err)

--- a/local/v1_facade.go
+++ b/local/v1_facade.go
@@ -22,7 +22,7 @@ import (
 // The facade is never modified, but it may become the underlying v1.Image for imgutil.CNBImageCore images.
 // The underlying layers will return data if they are contained in the store.
 // By storing a pointer to the image store, callers can update the store to force the layers to return data.
-func newV1ImageFacadeFromInspect(dockerInspect types.ImageInspect, history []image.HistoryResponseItem, withStore *Store, downloadLayersOnAccess bool) (v1.Image, error) {
+func newV1ImageFacadeFromInspect(dockerInspect image.InspectResponse, history []image.HistoryResponseItem, withStore *Store, downloadLayersOnAccess bool) (v1.Image, error) {
 	rootFS, err := toV1RootFS(dockerInspect.RootFS)
 	if err != nil {
 		return nil, err

--- a/local/v1_facade.go
+++ b/local/v1_facade.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -97,7 +96,7 @@ func layersAddendum(layers []v1.Layer, history []v1.History, requestedType v1typ
 	return addendums
 }
 
-func toV1RootFS(dockerRootFS types.RootFS) (v1.RootFS, error) {
+func toV1RootFS(dockerRootFS image.RootFS) (v1.RootFS, error) {
 	diffIDs := make([]v1.Hash, len(dockerRootFS.Layers))
 	for idx, layer := range dockerRootFS.Layers {
 		hash, err := v1.NewHash(layer)

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -138,10 +138,10 @@ func AssertTrue(t *testing.T, p func() bool) {
 	}
 }
 
-var dockerCliVal dockercli.CommonAPIClient
+var dockerCliVal dockercli.APIClient
 var dockerCliOnce sync.Once
 
-func DockerCli(t *testing.T) dockercli.CommonAPIClient {
+func DockerCli(t *testing.T) dockercli.APIClient {
 	dockerCliOnce.Do(func() {
 		var dockerCliErr error
 		dockerCliVal, dockerCliErr = dockercli.NewClientWithOpts(dockercli.FromEnv, dockercli.WithVersion("1.38"))
@@ -170,7 +170,7 @@ func Eventually(t *testing.T, test func() bool, every time.Duration, timeout tim
 	}
 }
 
-func PullIfMissing(t *testing.T, docker dockercli.CommonAPIClient, ref string) {
+func PullIfMissing(t *testing.T, docker dockercli.APIClient, ref string) {
 	t.Helper()
 	_, _, err := docker.ImageInspectWithRaw(context.TODO(), ref)
 	if err == nil {
@@ -194,7 +194,7 @@ func PullIfMissing(t *testing.T, docker dockercli.CommonAPIClient, ref string) {
 	AssertNil(t, err)
 }
 
-func DockerRmi(dockerCli dockercli.CommonAPIClient, repoNames ...string) error {
+func DockerRmi(dockerCli dockercli.APIClient, repoNames ...string) error {
 	var err error
 	ctx := context.Background()
 	for _, repoName := range repoNames {
@@ -211,7 +211,7 @@ func DockerRmi(dockerCli dockercli.CommonAPIClient, repoNames ...string) error {
 }
 
 // PushImage pushes an image to a registry, optionally using credentials from any set DOCKER_CONFIG
-func PushImage(t *testing.T, _ dockercli.CommonAPIClient, refStr string) {
+func PushImage(t *testing.T, _ dockercli.APIClient, refStr string) {
 	t.Helper()
 	Run(t, exec.Command("docker", "push", refStr)) // #nosec G204
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -260,7 +260,7 @@ func DeleteRegistryBlob(t *testing.T, repoName string, digest v1.Hash, encodedAu
 
 func ImageID(t *testing.T, repoName string) string {
 	t.Helper()
-	inspect, _, err := DockerCli(t).ImageInspectWithRaw(context.Background(), repoName)
+	inspect, err := DockerCli(t).ImageInspect(context.Background(), repoName)
 	AssertNil(t, err)
 	return inspect.ID
 }

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -172,7 +172,7 @@ func Eventually(t *testing.T, test func() bool, every time.Duration, timeout tim
 
 func PullIfMissing(t *testing.T, docker dockercli.APIClient, ref string) {
 	t.Helper()
-	_, _, err := docker.ImageInspectWithRaw(context.TODO(), ref)
+	_, err := docker.ImageInspect(context.TODO(), ref)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
Skaffold (github.com/googlecontainertools/skaffold) depends on imgutil as a dependency. We are trying to update to the latest docker package versions but unfortunately there are some braking changes between v26 and v28. This is my attempt at upgrading docker in imgutil and fixing the broken API.