### PR TITLE
containerd: optimizations

### DIFF
--- a/local/store.go
+++ b/local/store.go
@@ -35,6 +35,10 @@ type Store struct {
 	// optional
 	downloadOnce         *sync.Once
 	onDiskLayersByDiffID map[v1.Hash]annotatedLayer
+
+	// containerd storage detection cache
+	containerdStorageCache     *bool
+	containerdStorageCacheLock sync.RWMutex
 }
 
 // DockerClient is subset of client.APIClient required by this package.
@@ -89,17 +93,20 @@ func (s *Store) Save(img *Image, withName string, withAdditionalNames ...string)
 	)
 
 	// save
-	canOmitBaseLayers := !usesContainerdStorage(s.dockerClient)
+	isContainerdStorage := s.usesContainerdStorageCached()
+	canOmitBaseLayers := !isContainerdStorage
+
 	if canOmitBaseLayers {
 		// During the first save attempt some layers may be excluded.
 		// The docker daemon allows this if the given set of layers already exists in the daemon in the given order.
-		inspect, err = s.doSave(img, withName)
+		inspect, err = s.doSave(img, withName, isContainerdStorage)
 	}
 	if !canOmitBaseLayers || err != nil {
 		if err = img.ensureLayers(); err != nil {
 			return "", err
 		}
-		inspect, err = s.doSave(img, withName)
+
+		inspect, err = s.doSave(img, withName, isContainerdStorage)
 		if err != nil {
 			saveErr := imgutil.SaveError{}
 			for _, n := range append([]string{withName}, withAdditionalNames...) {
@@ -116,6 +123,7 @@ func (s *Store) Save(img *Image, withName string, withAdditionalNames ...string)
 			errs = append(errs, imgutil.SaveDiagnostic{ImageName: n, Cause: err})
 		}
 	}
+
 	if len(errs) > 0 {
 		return "", imgutil.SaveError{Errors: errs}
 	}
@@ -130,6 +138,30 @@ func tryNormalizing(name string) string {
 		return name
 	}
 	return t.Name() // returns valid 'name:tag' appending 'latest', if missing tag
+}
+
+// usesContainerdStorageCached provides cached containerd storage detection
+func (s *Store) usesContainerdStorageCached() bool {
+	s.containerdStorageCacheLock.RLock()
+	if s.containerdStorageCache != nil {
+		result := *s.containerdStorageCache
+		s.containerdStorageCacheLock.RUnlock()
+		return result
+	}
+	s.containerdStorageCacheLock.RUnlock()
+
+	// Need to compute and cache
+	s.containerdStorageCacheLock.Lock()
+	defer s.containerdStorageCacheLock.Unlock()
+
+	// Double-check after acquiring write lock
+	if s.containerdStorageCache != nil {
+		return *s.containerdStorageCache
+	}
+
+	result := usesContainerdStorage(s.dockerClient)
+	s.containerdStorageCache = &result
+	return result
 }
 
 func usesContainerdStorage(docker DockerClient) bool {
@@ -147,7 +179,7 @@ func usesContainerdStorage(docker DockerClient) bool {
 	return false
 }
 
-func (s *Store) doSave(img v1.Image, withName string) (image.InspectResponse, error) {
+func (s *Store) doSave(img v1.Image, withName string, isContainerdStorage bool) (image.InspectResponse, error) {
 	ctx := context.Background()
 	done := make(chan error)
 
@@ -155,7 +187,9 @@ func (s *Store) doSave(img v1.Image, withName string) (image.InspectResponse, er
 	pr, pw := io.Pipe()
 	defer pw.Close()
 
+	// Start the ImageLoad goroutine
 	go func() {
+
 		res, err := s.dockerClient.ImageLoad(ctx, pr, client.ImageLoadWithQuiet(true))
 		if err != nil {
 			done <- err
@@ -165,6 +199,7 @@ func (s *Store) doSave(img v1.Image, withName string) (image.InspectResponse, er
 		// only return the response error after the response is drained and closed
 		responseErr := checkResponseError(res.Body)
 		drainCloseErr := ensureReaderClosed(res.Body)
+
 		if responseErr != nil {
 			done <- responseErr
 			return
@@ -176,19 +211,25 @@ func (s *Store) doSave(img v1.Image, withName string) (image.InspectResponse, er
 		done <- nil
 	}()
 
+	// Create tar content
 	tw := tar.NewWriter(pw)
 	defer tw.Close()
 
-	if err = s.addImageToTar(tw, img, withName); err != nil {
+	if err = s.addImageToTar(tw, img, withName, isContainerdStorage); err != nil {
 		return image.InspectResponse{}, err
 	}
+
 	tw.Close()
 	pw.Close()
+
+	// Wait for ImageLoad to complete
 	err = <-done
+
 	if err != nil {
 		return image.InspectResponse{}, fmt.Errorf("loading image %q. first error: %w", withName, err)
 	}
 
+	// Inspect the saved image
 	inspect, err := s.dockerClient.ImageInspect(context.Background(), withName)
 	if err != nil {
 		if cerrdefs.IsNotFound(err) {
@@ -196,10 +237,12 @@ func (s *Store) doSave(img v1.Image, withName string) (image.InspectResponse, er
 		}
 		return image.InspectResponse{}, err
 	}
+
 	return inspect, nil
 }
 
-func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string) error {
+func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string, isContainerdStorage bool) error {
+	// Add config file
 	rawConfigFile, err := image.RawConfigFile()
 	if err != nil {
 		return err
@@ -208,23 +251,197 @@ func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string) e
 	if err = addTextToTar(tw, rawConfigFile, configHash+".json"); err != nil {
 		return err
 	}
+
+	// Get layers
 	layers, err := image.Layers()
 	if err != nil {
 		return err
 	}
-	var (
-		layerPaths []string
-		blankIdx   int
-	)
-	for _, layer := range layers {
-		layerName, err := s.addLayerToTar(tw, layer, blankIdx)
-		if err != nil {
-			return err
-		}
-		blankIdx++
-		layerPaths = append(layerPaths, layerName)
+
+	// Pre-process layers in parallel, then write to tar sequentially
+
+	// Parallel Processing Optimization: Prepare layer metadata concurrently, then write sequentially
+	// This overlaps the expensive layer reader preparation while maintaining tar format integrity.
+	// Prepare layer metadata in parallel
+	type layerInfo struct {
+		index   int
+		name    string
+		size    int64
+		diffID  v1.Hash
+		isBlank bool
+		reader  io.ReadCloser
+		err     error
 	}
 
+	layerInfos := make([]*layerInfo, len(layers))
+
+	// Parallel preparation phase
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Limit concurrent layer preparation to avoid too many open file handles
+	maxConcurrency := 3
+	if len(layers) < maxConcurrency {
+		maxConcurrency = len(layers)
+	}
+	semaphore := make(chan struct{}, maxConcurrency)
+
+	for i, layer := range layers {
+		i, layer := i, layer // capture loop variables
+		layerInfos[i] = &layerInfo{index: i}
+
+		g.Go(func() error {
+			// Acquire semaphore
+			select {
+			case semaphore <- struct{}{}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			defer func() { <-semaphore }()
+
+			info := layerInfos[i]
+
+			// Get layer size to determine if it's blank
+			size, err := layer.Size()
+			if err != nil {
+				info.err = err
+				return err
+			}
+			info.size = size
+
+			if size == -1 {
+				// Blank layer
+				info.isBlank = true
+				info.name = fmt.Sprintf("blank_%d", i)
+				return nil
+			}
+
+			// Get diff ID for non-blank layers
+			diffID, err := layer.DiffID()
+			if err != nil {
+				info.err = err
+				return err
+			}
+			info.diffID = diffID
+			info.name = fmt.Sprintf("/%s.tar", diffID.String())
+
+			// Pre-open the reader to check for errors early
+			reader, err := layer.Uncompressed()
+			if err != nil {
+				info.err = err
+				return err
+			}
+			info.reader = reader
+
+			return nil
+		})
+	}
+
+	// Wait for all preparation to complete
+	if err := g.Wait(); err != nil {
+		// Close any opened readers on error
+		for _, info := range layerInfos {
+			if info.reader != nil {
+				info.reader.Close()
+			}
+		}
+		return err
+	}
+
+	// Sequential tar writing phase
+	var layerPaths []string
+
+	for i, info := range layerInfos {
+		if info.err != nil {
+			return info.err
+		}
+
+		if info.isBlank {
+			// Write blank layer
+			hdr := &tar.Header{Name: info.name, Mode: 0644, Size: 0}
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+		} else {
+			// Write populated layer
+			defer info.reader.Close()
+
+			// CONTAINERD OPTIMIZATION: For containerd, calculate size efficiently during tar writing
+			var uncompressedSize int64
+			var err error
+
+			if isContainerdStorage {
+				// For containerd, use Docker-native format bypass optimization
+
+				// Docker-Native Bypass: Skip custom tar creation, use existing layer files directly
+
+				// Use the layer's existing compressed format if available
+				// This mimics what docker save/load does natively
+				compressedReader, err := layers[i].Compressed()
+				if err != nil {
+					// Fallback to uncompressed if compressed not available
+					compressedReader = info.reader
+				} else {
+					// Close the uncompressed reader since we're using compressed
+					info.reader.Close()
+				}
+				defer compressedReader.Close()
+
+				// Stream compressed data directly to tar (Docker-native format)
+				tempFile, err := os.CreateTemp("", "compressed-layer-*.tar")
+				if err != nil {
+					return err
+				}
+				defer os.Remove(tempFile.Name())
+				defer tempFile.Close()
+
+				// Calculate size while streaming to temp file
+				bytesRead, err := io.Copy(tempFile, compressedReader)
+				if err != nil {
+					return err
+				}
+				uncompressedSize = bytesRead
+
+				// Rewind temp file for reading
+				if _, err := tempFile.Seek(0, 0); err != nil {
+					return err
+				}
+
+				// Write tar header with calculated size (Docker-native format)
+				hdr := &tar.Header{Name: info.name, Mode: 0644, Size: uncompressedSize}
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+
+				// Stream from temp file to tar
+				_, err = io.Copy(tw, tempFile)
+				if err != nil {
+					return err
+				}
+			} else {
+				// For standard Docker storage, use cached size calculation (existing behavior)
+				uncompressedSize, err = s.getLayerSize(layers[i])
+				if err != nil {
+					return err
+				}
+
+				// Write tar header with cached size
+				hdr := &tar.Header{Name: info.name, Mode: 0644, Size: uncompressedSize}
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
+
+				// Copy layer data
+				_, err = io.Copy(tw, info.reader)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		layerPaths = append(layerPaths, info.name)
+	}
+
+	// Add manifest
 	manifestJSON, err := json.Marshal([]map[string]interface{}{
 		{
 			"Config":   configHash + ".json",
@@ -235,48 +452,11 @@ func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string) e
 	if err != nil {
 		return err
 	}
-	return addTextToTar(tw, manifestJSON, "manifest.json")
-}
-
-func (s *Store) addLayerToTar(tw *tar.Writer, layer v1.Layer, blankIdx int) (string, error) {
-	// If the layer is a previous image layer that hasn't been downloaded yet,
-	// cause ALL the previous image layers to be downloaded by grabbing the ReadCloser.
-	layerReader, err := layer.Uncompressed()
-	if err != nil {
-		return "", err
-	}
-	defer layerReader.Close()
-
-	var layerName string
-	size, err := layer.Size()
-	if err != nil {
-		return "", err
-	}
-	if size == -1 { // it's a base (always empty) layer
-		layerName = fmt.Sprintf("blank_%d", blankIdx)
-		hdr := &tar.Header{Name: layerName, Mode: 0644, Size: 0}
-		return layerName, tw.WriteHeader(hdr)
-	}
-	// it's a populated layer
-	layerDiffID, err := layer.DiffID()
-	if err != nil {
-		return "", err
-	}
-	layerName = fmt.Sprintf("/%s.tar", layerDiffID.String())
-
-	uncompressedSize, err := s.getLayerSize(layer)
-	if err != nil {
-		return "", err
-	}
-	hdr := &tar.Header{Name: layerName, Mode: 0644, Size: uncompressedSize}
-	if err = tw.WriteHeader(hdr); err != nil {
-		return "", err
-	}
-	if _, err = io.Copy(tw, layerReader); err != nil {
-		return "", err
+	if err = addTextToTar(tw, manifestJSON, "manifest.json"); err != nil {
+		return err
 	}
 
-	return layerName, nil
+	return nil
 }
 
 // getLayerSize returns the uncompressed layer size.
@@ -288,14 +468,17 @@ func (s *Store) getLayerSize(layer v1.Layer) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	knownLayer, layerFound := s.onDiskLayersByDiffID[diffID]
 	if layerFound && knownLayer.uncompressedSize != -1 {
 		return knownLayer.uncompressedSize, nil
 	}
+
 	// FIXME: this is a time sink and should be avoided if the daemon accepts OCI layout-formatted tars
 	// If layer was not seen previously, we need to read it to get the uncompressed size
 	// In practice, we should only get here if layers saved from the daemon via `docker save`
 	// are output compressed.
+
 	layerReader, err := layer.Uncompressed()
 	if err != nil {
 		return 0, err
@@ -307,6 +490,7 @@ func (s *Store) getLayerSize(layer v1.Layer) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return size, nil
 }
 
@@ -380,7 +564,7 @@ func (s *Store) SaveFile(image *Image, withName string) (string, error) {
 		tw := tar.NewWriter(pw)
 		defer tw.Close()
 
-		return s.addImageToTar(tw, image, withName)
+		return s.addImageToTar(tw, image, withName, s.usesContainerdStorageCached())
 	})
 
 	err = errs.Wait()
@@ -453,12 +637,47 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 		return err
 	}
 
-	for idx := range configFile.RootFS.DiffIDs {
-		layerPath := filepath.Join(tmpDir, manifest[0].Layers[idx])
-		if _, err := s.AddLayer(layerPath); err != nil {
-			return err
-		}
+	// Parallel Processing Optimization: Process multiple layers concurrently during download
+	// This can significantly reduce wall-clock time, especially for containerd storage where
+	// layers are downloaded fresh and need expensive uncompressed size calculations.
+	// Use errgroup for parallel layer processing with bounded concurrency
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Limit concurrent layer processing to avoid overwhelming the system
+	// Use a reasonable number based on typical layer counts and system resources
+	maxConcurrency := 4
+	if len(configFile.RootFS.DiffIDs) < maxConcurrency {
+		maxConcurrency = len(configFile.RootFS.DiffIDs)
 	}
+
+	// Create a channel to limit concurrency
+	semaphore := make(chan struct{}, maxConcurrency)
+
+	for idx := range configFile.RootFS.DiffIDs {
+		idx := idx // capture loop variable
+		g.Go(func() error {
+			// Acquire semaphore
+			select {
+			case semaphore <- struct{}{}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			defer func() { <-semaphore }() // Release semaphore
+
+			layerPath := filepath.Join(tmpDir, manifest[0].Layers[idx])
+
+			if _, err := s.AddLayer(layerPath); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+
+	// Wait for all layers to complete
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -542,15 +761,22 @@ func (s *Store) findLayer(withHash v1.Hash) v1.Layer {
 	return aLayer.layer
 }
 
+// AddLayer adds a layer from a file path to the store's cache.
+// This method includes a performance optimization: for compressed layers, it proactively
+// calculates the uncompressed size during the add operation to avoid expensive cache misses
+// later during tar creation. This optimization is particularly important for containerd storage
+// scenarios where layers are downloaded fresh and don't have cached uncompressed sizes.
 func (s *Store) AddLayer(fromPath string) (v1.Layer, error) {
 	layer, err := tarball.LayerFromFile(fromPath)
 	if err != nil {
 		return nil, err
 	}
+
 	diffID, err := layer.DiffID()
 	if err != nil {
 		return nil, err
 	}
+
 	var uncompressedSize int64
 	fileSize, err := func() (int64, error) {
 		fi, err := os.Stat(fromPath)
@@ -562,19 +788,46 @@ func (s *Store) AddLayer(fromPath string) (v1.Layer, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	compressedSize, err := layer.Size()
 	if err != nil {
 		return nil, err
 	}
+
 	if fileSize == compressedSize {
-		// the layer is compressed, we don't know the uncompressed size
-		uncompressedSize = -1
+		// the layer is compressed
+
+		// CONTAINERD OPTIMIZATION: Skip expensive size calculation during download for containerd
+		// We'll calculate it more efficiently during tar creation
+		if s.usesContainerdStorageCached() {
+			uncompressedSize = -1 // Will be calculated efficiently during tar creation
+		} else {
+			// For standard Docker storage, calculate size now to avoid cache misses later
+
+			layerReader, err := layer.Uncompressed()
+			if err != nil {
+				// Fall back to unknown size to maintain backward compatibility
+				uncompressedSize = -1
+			} else {
+				defer layerReader.Close()
+				var calculatedSize int64
+				calculatedSize, err = io.Copy(io.Discard, layerReader)
+				if err != nil {
+					// Fall back to unknown size to maintain backward compatibility
+					uncompressedSize = -1
+				} else {
+					uncompressedSize = calculatedSize
+				}
+			}
+		}
 	} else {
 		uncompressedSize = fileSize
 	}
+
 	s.onDiskLayersByDiffID[diffID] = annotatedLayer{
 		layer:            layer,
 		uncompressedSize: uncompressedSize,
 	}
+
 	return layer, nil
 }

--- a/local/store.go
+++ b/local/store.go
@@ -189,7 +189,6 @@ func (s *Store) doSave(img v1.Image, withName string, isContainerdStorage bool) 
 
 	// Start the ImageLoad goroutine
 	go func() {
-
 		res, err := s.dockerClient.ImageLoad(ctx, pr, client.ImageLoadWithQuiet(true))
 		if err != nil {
 			done <- err


### PR DESCRIPTION
This pull request introduces significant performance optimizations and code improvements to the image saving and layer handling logic in `local/store.go`, with a focus on supporting containerd storage scenarios more efficiently. The main changes include implementing caching for containerd storage detection, optimizing layer processing by introducing parallelism, and improving how layer sizes are calculated and cached. These updates are especially beneficial for environments using containerd, leading to faster image saves and more efficient resource usage.

**Performance optimizations for containerd storage:**

* Added a cached detection mechanism for containerd storage in the `Store` struct and used it throughout the codebase to avoid redundant checks and improve performance. (`containerdStorageCache`, `usesContainerdStorageCached`) [[1]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R38-R41) [[2]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R143-R166)
* Optimized the process of adding image layers to tar files by pre-processing layer metadata in parallel and streaming layer data more efficiently, with special handling for containerd storage to minimize expensive uncompressed size calculations.
* Improved the `AddLayer` method to proactively calculate (or defer) the uncompressed size of compressed layers, optimizing for containerd by skipping unnecessary calculations during download and only performing them when required. [[1]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R764-R779) [[2]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R791-R831)

**Parallelization and concurrency improvements:**

* Introduced parallel processing using `errgroup` and semaphores in both layer preparation for tar creation and during layer downloads, reducing wall-clock time and making better use of system resources. [[1]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R254-R459) [[2]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R640-R680)

**API and function signature updates:**

* Updated several internal function signatures (e.g., `doSave`, `addImageToTar`) to accept an `isContainerdStorage` flag, ensuring the optimizations are applied conditionally based on the storage backend. [[1]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4L92-R109) [[2]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4L150-R192) [[3]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4R214-R245) [[4]](diffhunk://#diff-709433ce474b786dd6970e2bbbe23bdb9598b9b980d51436cdd00388ce4082b4L383-R567)

These changes collectively enhance the efficiency and scalability of image saving and layer management, especially when working with containerd-based Docker setups.


Note: the streaming of the existing layer files is the biggest win here by a large margin

This is an effort to close out https://github.com/buildpacks/pack/issues/2272 and make sure perf is decent on docker's containerd storage option.


Using @edmorley 's slightly modified example in the issue above. This is a subsequent `pack build`. I've only extracted the Export numbers here as this isn't targeting the other `pack` inefficiencies.

baseline non-`containerd` storage current lifecycle:
```
2025/08/08 10:44:20.176273 [exporter] Saving testcase...
2025/08/08 10:44:20.213789 [exporter] *** Images (6c4091617b09):
2025/08/08 10:44:20.213810 [exporter]       testcase
2025/08/08 10:44:20.213815 [exporter]
2025/08/08 10:44:20.213819 [exporter] *** Image ID: 6c4091617b09fd8c1dcbe214c22785e55497a1b1882c3f454634ee1b6735d99f
2025/08/08 10:44:20.213824 [exporter]
2025/08/08 10:44:20.213827 [exporter] *** Manifest Size: 1087
2025/08/08 10:44:20.213829 [exporter] Timer: Saving testcase... ran for 37.526ms and ended at 2025-08-08T15:44:20Z
2025/08/08 10:44:20.213832 [exporter] Timer: Exporter ran for 66.211458ms and ended at 2025-08-08T15:44:20Z
2025/08/08 10:44:20.213904 [exporter] Timer: Cache started at 2025-08-08T15:44:20Z
```

`containerd` storage current lifecycle:
```
$ pack build --builder testbuilder:24 --pull-policy if-not-present --timestamps --verbose --buildpack heroku/procfile testcase
2025/08/08 10:43:08.903421 [exporter] Saving testcase...
2025/08/08 10:43:17.900220 [exporter] *** Images (e4de4e43ad71):
2025/08/08 10:43:17.900242 [exporter]       testcase
2025/08/08 10:43:17.900246 [exporter]
2025/08/08 10:43:17.900249 [exporter] *** Image ID: e4de4e43ad7143ad0d5c3a4b6e28ff1bca059713c78879e35cee8c3236cde8e0
2025/08/08 10:43:17.900255 [exporter]
2025/08/08 10:43:17.900258 [exporter] *** Manifest Size: 1087
2025/08/08 10:43:17.900260 [exporter] Timer: Saving testcase... ran for 8.996857171s and ended at 2025-08-08T15:43:17Z
2025/08/08 10:43:17.900262 [exporter] Timer: Exporter ran for 9.027226629s and ended at 2025-08-08T15:43:17Z
2025/08/08 10:43:17.900521 [exporter] Timer: Cache started at 2025-08-08T15:43:17Z
```

`containerd` storage improved lifecycle:
```
$ pack build --builder testbuilder:24 --pull-policy if-not-present --timestamps --verbose --buildpack heroku/procfile --lifecycle-image lifecycle:test testcase
2025/08/08 10:40:33.692477 [exporter] Saving testcase...
2025/08/08 10:40:36.632895 [exporter] *** Images (8a71eb3516e7):
2025/08/08 10:40:36.632916 [exporter]       testcase
2025/08/08 10:40:36.632920 [exporter]
2025/08/08 10:40:36.632924 [exporter] *** Image ID: 8a71eb3516e7ee4993c5363bfd719bd57c459d7d801818f60e4a537f3eef30ce
2025/08/08 10:40:36.632927 [exporter]
2025/08/08 10:40:36.632930 [exporter] *** Manifest Size: 1086
2025/08/08 10:40:36.632932 [exporter] Timer: Saving testcase... ran for 2.940171127s and ended at 2025-08-08T15:40:36Z
2025/08/08 10:40:36.632935 [exporter] Timer: Exporter ran for 2.968824459s and ended at 2025-08-08T15:40:36Z
2025/08/08 10:40:36.632938 [exporter] Timer: Cache started at 2025-08-08T15:40:36Z
```

We are never going to get to pre-`containerd` perf due to the cheat we were using before. We now have to give the docker daemon layers we were entirely able to skip before. Those layers are also the bigger base layers. We are much closer to `docker load <exported>` on a clean docker installation though. IME it was about ~1.7s.