### PR TITLE
Always try the fast path first (omitting base layers) regardless of storage type

### DIFF
--- a/local/store.go
+++ b/local/store.go
@@ -260,7 +260,7 @@ func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string, i
 		layerPaths []string
 		blankIdx   int
 	)
-	for i, layer := range layers {
+	for _, layer := range layers {
 		// If the layer is a previous image layer that hasn't been downloaded yet,
 		// cause ALL the previous image layers to be downloaded by grabbing the ReadCloser.
 		layerReader, err := layer.Uncompressed()

--- a/local/store.go
+++ b/local/store.go
@@ -94,14 +94,13 @@ func (s *Store) Save(img *Image, withName string, withAdditionalNames ...string)
 
 	// save
 	isContainerdStorage := s.usesContainerdStorageCached()
-	canOmitBaseLayers := !isContainerdStorage
 
-	if canOmitBaseLayers {
-		// During the first save attempt some layers may be excluded.
-		// The docker daemon allows this if the given set of layers already exists in the daemon in the given order.
-		inspect, err = s.doSave(img, withName, isContainerdStorage)
-	}
-	if !canOmitBaseLayers || err != nil {
+	// During the first save attempt some layers may be excluded.
+	// The docker daemon allows this if the given set of layers already exists in the daemon in the given order.
+	inspect, err = s.doSave(img, withName, isContainerdStorage)
+
+	// If the fast save fails, we need to ensure the layers and try again.
+	if err != nil {
 		if err = img.ensureLayers(); err != nil {
 			return "", err
 		}
@@ -261,7 +260,7 @@ func (s *Store) addImageToTar(tw *tar.Writer, image v1.Image, withName string, i
 		layerPaths []string
 		blankIdx   int
 	)
-	for _, layer := range layers {
+	for i, layer := range layers {
 		// If the layer is a previous image layer that hasn't been downloaded yet,
 		// cause ALL the previous image layers to be downloaded by grabbing the ReadCloser.
 		layerReader, err := layer.Uncompressed()


### PR DESCRIPTION
In my testing - trying to fast path works wonders on containerd storage layer now. I'm not entirely sure if this is because of upstream changes or other imgutil changes over time. An ephemeral builder creation goes from 6s back down to 10ms or less.

This is a partial revert of https://github.com/buildpacks/imgutil/pull/256


This fixes the first part of https://github.com/buildpacks/pack/issues/2272 for me. An untrusted ephemeral builder is much faster. The `image.Save` falls into the optimized path and doesn't have to do the slow `ensureLayers`
