### PR TITLE
Add index annotation support

### DIFF
--- a/cnb_index.go
+++ b/cnb_index.go
@@ -1,6 +1,7 @@
 package imgutil
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -142,6 +143,11 @@ func (h *CNBIndex) SetAnnotations(digest name.Digest, annotations map[string]str
 	})
 }
 
+func (h *CNBIndex) SetIndexAnnotations(annotations map[string]string) (err error) {
+	h.ImageIndex = mutate.Annotations(h.ImageIndex, annotations).(v1.ImageIndex)
+	return nil
+}
+
 func (h *CNBIndex) SetArchitecture(digest name.Digest, arch string) (err error) {
 	return h.replaceDescriptor(digest, func(descriptor v1.Descriptor) (v1.Descriptor, error) {
 		descriptor.Platform.Architecture = arch
@@ -256,7 +262,7 @@ func (h *CNBIndex) SaveDir() error {
 	if len(errs.Errors) != 0 {
 		return errs
 	}
-	return nil
+	return writeIndexAnnotations(path, index.Annotations)
 }
 
 func appendManifest(desc v1.Descriptor, path layout.Path, errs *SaveError) {
@@ -270,6 +276,31 @@ func appendManifest(desc v1.Descriptor, path layout.Path, errs *SaveError) {
 			Cause: err,
 		})
 	}
+}
+
+func writeIndexAnnotations(path layout.Path, annotations map[string]string) error {
+	if len(annotations) == 0 {
+		return nil
+	}
+
+	imageIndex, err := path.ImageIndex()
+	if err != nil {
+		return err
+	}
+
+	index, err := imageIndex.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	index.Annotations = annotations
+
+	rawIndex, err := json.MarshalIndent(index, "", "   ")
+	if err != nil {
+		return err
+	}
+
+	return path.WriteFile("index.json", rawIndex, os.ModePerm)
 }
 
 func newEmptyLayoutPath(indexType types.MediaType, path string) (layout.Path, error) {

--- a/cnb_index_test.go
+++ b/cnb_index_test.go
@@ -1,0 +1,137 @@
+package imgutil_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/buildpacks/imgutil"
+)
+
+func TestCNBIndexSetIndexAnnotations(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		mediaType         types.MediaType
+		expectedMediaType types.MediaType
+	}{
+		{
+			name:              "oci index",
+			expectedMediaType: types.OCIImageIndex,
+		},
+		{
+			name:              "docker index",
+			mediaType:         types.DockerManifestList,
+			expectedMediaType: types.DockerManifestList,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repoName := "some/index"
+
+			index, err := imgutil.NewCNBIndex(repoName, imgutil.IndexOptions{
+				MediaType: test.mediaType,
+				LayoutIndexOptions: imgutil.LayoutIndexOptions{
+					XdgPath: tmpDir,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			image, err := random.Image(1024, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			index.AddManifest(image)
+
+			existingAnnotations := map[string]string{
+				"existing-key": "existing-value",
+				"shared-key":   "old-value",
+			}
+			if err := index.SetIndexAnnotations(existingAnnotations); err != nil {
+				t.Fatal(err)
+			}
+
+			newAnnotations := map[string]string{
+				"some-index-key": "some-index-value",
+				"shared-key":     "new-value",
+			}
+			if err := index.SetIndexAnnotations(newAnnotations); err != nil {
+				t.Fatal(err)
+			}
+			if err := index.SaveDir(); err != nil {
+				t.Fatal(err)
+			}
+
+			expectedAnnotations := map[string]string{
+				"existing-key":   "existing-value",
+				"some-index-key": "some-index-value",
+				"shared-key":     "new-value",
+			}
+			indexManifest := readIndexManifest(t, tmpDir, repoName)
+			if diff := cmp.Diff(expectedAnnotations, indexManifest.Annotations); diff != "" {
+				t.Fatalf("unexpected index annotations (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(test.expectedMediaType, indexManifest.MediaType); diff != "" {
+				t.Fatalf("unexpected index media type (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(1, len(indexManifest.Manifests)); diff != "" {
+				t.Fatalf("unexpected manifest count (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCNBIndexSaveDirWithoutIndexAnnotations(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoName := "some/index"
+
+	index, err := imgutil.NewCNBIndex(repoName, imgutil.IndexOptions{
+		LayoutIndexOptions: imgutil.LayoutIndexOptions{
+			XdgPath: tmpDir,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index.AddManifest(image)
+
+	if err := index.SaveDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	indexManifest := readIndexManifest(t, tmpDir, repoName)
+	if diff := cmp.Diff(map[string]string(nil), indexManifest.Annotations); diff != "" {
+		t.Fatalf("unexpected index annotations (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(1, len(indexManifest.Manifests)); diff != "" {
+		t.Fatalf("unexpected manifest count (-want +got):\n%s", diff)
+	}
+}
+
+func readIndexManifest(t *testing.T, tmpDir, repoName string) v1.IndexManifest {
+	t.Helper()
+
+	rawIndex, err := os.ReadFile(filepath.Join(tmpDir, imgutil.MakeFileSafeName(repoName), "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var indexManifest v1.IndexManifest
+	if err := json.Unmarshal(rawIndex, &indexManifest); err != nil {
+		t.Fatal(err)
+	}
+
+	return indexManifest
+}

--- a/fakes/image_index.go
+++ b/fakes/image_index.go
@@ -73,6 +73,11 @@ func (i ImageIndex) SetAnnotations(_ name.Digest, _ map[string]string) error {
 	panic("unimplemented")
 }
 
+// SetIndexAnnotations implements imgutil.ImageIndex.
+func (i ImageIndex) SetIndexAnnotations(_ map[string]string) error {
+	panic("unimplemented")
+}
+
 // SetArchitecture implements imgutil.ImageIndex.
 func (i ImageIndex) SetArchitecture(_ name.Digest, _ string) error {
 	panic("unimplemented")

--- a/index.go
+++ b/index.go
@@ -19,6 +19,7 @@ type ImageIndex interface {
 	// setters
 
 	SetAnnotations(digest name.Digest, annotations map[string]string) (err error)
+	SetIndexAnnotations(annotations map[string]string) (err error)
 	SetArchitecture(digest name.Digest, arch string) (err error)
 	SetOS(digest name.Digest, os string) (err error)
 	SetVariant(digest name.Digest, osVariant string) (err error)


### PR DESCRIPTION
## Summary
- added `ImageIndex.SetIndexAnnotations` for top-level index annotations
- applied index annotations through go-containerregistry's index annotation mutation
- preserved top-level annotations when `SaveDir()` rewrites the local `index.json`
- updated the fake `ImageIndex`
- added unit coverage for OCI and Docker manifest list index annotations, no-annotation saves, and merge/update behavior for existing index annotation keys

## Context
This is the imgutil prerequisite for buildpacks/pack#2586. The pack-side `manifest annotate --index` flow needs an imgutil API that can write annotations to the index manifest itself, not only to a manifest descriptor inside the index.

## Tests
- `go test . -run TestCNBIndexSetIndexAnnotations -count=1`
- `go test . -run 'TestCNBIndex(SetIndexAnnotations|SaveDirWithoutIndexAnnotations)' -count=1`
- `go test . -count=1`
- `go test ./... -run '^$' -count=1`
- `make format`

GitHub checks passed on the latest commit (`6ad67aa`): DCO, Linux, Linux containerd, Windows, Codecov patch, and Codecov project.

Local Docker-dependent tests could not be run because this machine has no Docker socket at `/var/run/docker.sock`:
- `go test ./layout -run TestLayoutIndex -count=1`
- `go test ./fakes -count=1`
