### PR TITLE
Fix off-by-one bounds check in layout layer facade

### DIFF
--- a/layout/v1_facade.go
+++ b/layout/v1_facade.go
@@ -133,10 +133,10 @@ func newLayerOrFacadeFrom(configFile v1.ConfigFile, manifestFile v1.Manifest, la
 	if hasData(originalLayer) {
 		return originalLayer, nil
 	}
-	if layerIndex > len(configFile.RootFS.DiffIDs) {
+	if layerIndex >= len(configFile.RootFS.DiffIDs) {
 		return nil, fmt.Errorf("failed to find layer for index %d in config file", layerIndex)
 	}
-	if layerIndex > (len(manifestFile.Layers)) {
+	if layerIndex >= len(manifestFile.Layers) {
 		return nil, fmt.Errorf("failed to find layer for index %d in manifest file", layerIndex)
 	}
 	return &v1LayerFacade{

--- a/layout/v1_facade_test.go
+++ b/layout/v1_facade_test.go
@@ -1,0 +1,85 @@
+package layout
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	h "github.com/buildpacks/imgutil/testhelpers"
+)
+
+func TestV1Facade(t *testing.T) {
+	spec.Run(t, "V1Facade", testV1Facade, spec.Parallel(), spec.Report(report.Terminal{}))
+}
+
+// dataLessLayer models a layer from a sparse image: its content isn't on disk,
+// so Compressed returns an error and hasData reports false.
+type dataLessLayer struct {
+	v1.Layer
+}
+
+func (l dataLessLayer) Compressed() (io.ReadCloser, error) {
+	return nil, errors.New("no data")
+}
+
+func testV1Facade(t *testing.T, when spec.G, it spec.S) {
+	when("#newLayerOrFacadeFrom", func() {
+		when("the layer index is out of bounds", func() {
+			it("errors when the config has fewer diffIDs than the manifest has layers", func() {
+				configFile := v1.ConfigFile{RootFS: v1.RootFS{DiffIDs: []v1.Hash{
+					{Algorithm: "sha256", Hex: "0000000000000000000000000000000000000000000000000000000000000000"},
+				}}}
+				manifestFile := v1.Manifest{Layers: []v1.Descriptor{
+					{Digest: v1.Hash{Algorithm: "sha256", Hex: "1111111111111111111111111111111111111111111111111111111111111111"}},
+					{Digest: v1.Hash{Algorithm: "sha256", Hex: "2222222222222222222222222222222222222222222222222222222222222222"}},
+				}}
+
+				_, err := newLayerOrFacadeFrom(configFile, manifestFile, 1, dataLessLayer{})
+
+				h.AssertError(t, err, "failed to find layer for index 1 in config file")
+			})
+
+			it("errors when the manifest has fewer layers than the config has diffIDs", func() {
+				configFile := v1.ConfigFile{RootFS: v1.RootFS{DiffIDs: []v1.Hash{
+					{Algorithm: "sha256", Hex: "0000000000000000000000000000000000000000000000000000000000000000"},
+					{Algorithm: "sha256", Hex: "3333333333333333333333333333333333333333333333333333333333333333"},
+				}}}
+				manifestFile := v1.Manifest{Layers: []v1.Descriptor{
+					{Digest: v1.Hash{Algorithm: "sha256", Hex: "1111111111111111111111111111111111111111111111111111111111111111"}},
+				}}
+
+				_, err := newLayerOrFacadeFrom(configFile, manifestFile, 1, dataLessLayer{})
+
+				h.AssertError(t, err, "failed to find layer for index 1 in manifest file")
+			})
+		})
+
+		when("the layer index is in bounds", func() {
+			it("returns a facade with the diffID, digest and size from the image", func() {
+				diffID := v1.Hash{Algorithm: "sha256", Hex: "0000000000000000000000000000000000000000000000000000000000000000"}
+				digest := v1.Hash{Algorithm: "sha256", Hex: "1111111111111111111111111111111111111111111111111111111111111111"}
+				configFile := v1.ConfigFile{RootFS: v1.RootFS{DiffIDs: []v1.Hash{diffID}}}
+				manifestFile := v1.Manifest{Layers: []v1.Descriptor{{Digest: digest, Size: 42}}}
+
+				layer, err := newLayerOrFacadeFrom(configFile, manifestFile, 0, dataLessLayer{})
+				h.AssertNil(t, err)
+
+				gotDiffID, err := layer.DiffID()
+				h.AssertNil(t, err)
+				h.AssertEq(t, gotDiffID, diffID)
+
+				gotDigest, err := layer.Digest()
+				h.AssertNil(t, err)
+				h.AssertEq(t, gotDigest, digest)
+
+				gotSize, err := layer.Size()
+				h.AssertNil(t, err)
+				h.AssertEq(t, gotSize, int64(42))
+			})
+		})
+	})
+}


### PR DESCRIPTION
The two bounds checks in `newLayerOrFacadeFrom` use `>` where they should use `>=`, so when `layerIndex` equals the slice length the guard doesn't fire and we fall straight through to `configFile.RootFS.DiffIDs[layerIndex]` / `manifestFile.Layers[layerIndex]`. That's an index out of range panic instead of the error the guard was there to return.

It's reachable through the layout facade: `newImageFacadeFrom` ranges over `original.Layers()` and hands each index to `newLayerOrFacadeFrom`, which then indexes into the config's diff_ids. Config and manifest get parsed independently and nothing cross-checks the counts, so an OCI layout image whose manifest lists more layer descriptors than the config has diff_ids (or the other way round) loads fine and then panics when it's used as a base or previous image. Only affects the facade path, so data-less/sparse layers.

Changing `>` to `>=` gets you the intended "failed to find layer for index N" error. Valid images are unaffected since a valid index never equals the array length.

Added `layout/v1_facade_test.go` covering both directions of the mismatch plus an in-bounds case. It's an in-package test since `newLayerOrFacadeFrom` isn't exported. Panics before the change, passes after, and `go test ./layout/...` is green.
