### PR TITLE
local: clean up daemon layer extract dirs after Save

### DIFF
--- a/local/store.go
+++ b/local/store.go
@@ -35,6 +35,12 @@ type Store struct {
 	downloadOnce         *sync.Once
 	onDiskLayersByDiffID map[v1.Hash]annotatedLayer
 	platform             imgutil.Platform
+	// downloadDirs holds temp dirs created while fetching base layers from the daemon
+	// (e.g. when sparse/omit-base-layer saves are not accepted, such as with podman).
+	// These are removed after Save/SaveFile so /tmp does not accumulate large layer extracts.
+	// Layers added explicitly via AddLayer (build artifacts) are not stored here.
+	downloadDirs      []string
+	downloadedDiffIDs []v1.Hash
 }
 
 // DockerClient is subset of client.APIClient required by this package.
@@ -91,6 +97,9 @@ func (s *Store) Delete(identifier string) error {
 }
 
 func (s *Store) Save(img *Image, withName string, withAdditionalNames ...string) (string, error) {
+	// Remove daemon-extracted layer dirs after save. New layers added via AddLayer are not affected.
+	defer s.cleanupDownloadDirs()
+
 	withName = tryNormalizing(withName)
 	var (
 		inspect image.InspectResponse
@@ -355,6 +364,9 @@ func ensureReaderClosed(r io.ReadCloser) error {
 }
 
 func (s *Store) SaveFile(image *Image, withName string) (string, error) {
+	// Same as Save: drop daemon-extracted layer dirs once they have been read into the export tar.
+	defer s.cleanupDownloadDirs()
+
 	withName = tryNormalizing(withName)
 
 	f, err := os.CreateTemp("", "imgutil.local.image.export.*.tar")
@@ -444,6 +456,13 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir: %w", err)
 	}
+	// On failure, remove immediately. On success, keep until Save/SaveFile finishes reading layers.
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
 
 	err = untar(imageReader, tmpDir)
 	if err != nil {
@@ -481,13 +500,43 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 		return err
 	}
 
+	var addedDiffIDs []v1.Hash
 	for idx := range configFile.RootFS.DiffIDs {
 		layerPath := filepath.Join(tmpDir, manifest[0].Layers[idx])
-		if _, err := s.AddLayer(layerPath); err != nil {
+		layer, err := s.AddLayer(layerPath)
+		if err != nil {
 			return err
 		}
+		diffID, err := layer.DiffID()
+		if err != nil {
+			return err
+		}
+		addedDiffIDs = append(addedDiffIDs, diffID)
 	}
+
+	s.downloadDirs = append(s.downloadDirs, tmpDir)
+	s.downloadedDiffIDs = append(s.downloadedDiffIDs, addedDiffIDs...)
+	keep = true
 	return nil
+}
+
+// cleanupDownloadDirs removes temp directories created by doDownloadLayersFor and drops
+// the corresponding layer handles. Layers registered via AddLayer from outside a download
+// (for example pack's create-builder-scratch artifacts) are left alone.
+func (s *Store) cleanupDownloadDirs() {
+	if len(s.downloadDirs) == 0 {
+		return
+	}
+	for _, dir := range s.downloadDirs {
+		_ = os.RemoveAll(dir)
+	}
+	s.downloadDirs = nil
+	for _, id := range s.downloadedDiffIDs {
+		delete(s.onDiskLayersByDiffID, id)
+	}
+	s.downloadedDiffIDs = nil
+	// Allow a future ensureLayers() to re-download if needed.
+	s.downloadOnce = &sync.Once{}
 }
 
 func untar(r io.Reader, dest string) error {

--- a/local/store.go
+++ b/local/store.go
@@ -458,9 +458,11 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 	}
 	// On failure, remove immediately. On success, keep until Save/SaveFile finishes reading layers.
 	keep := false
+	var addedDiffIDs []v1.Hash
 	defer func() {
 		if !keep {
 			_ = os.RemoveAll(tmpDir)
+			s.dropDownloadedLayerHandles(addedDiffIDs)
 		}
 	}()
 
@@ -500,7 +502,6 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 		return err
 	}
 
-	var addedDiffIDs []v1.Hash
 	for idx := range configFile.RootFS.DiffIDs {
 		layerPath := filepath.Join(tmpDir, manifest[0].Layers[idx])
 		layer, err := s.AddLayer(layerPath)
@@ -520,6 +521,12 @@ func (s *Store) doDownloadLayersFor(identifier string) error {
 	return nil
 }
 
+func (s *Store) dropDownloadedLayerHandles(ids []v1.Hash) {
+	for _, id := range ids {
+		delete(s.onDiskLayersByDiffID, id)
+	}
+}
+
 // cleanupDownloadDirs removes temp directories created by doDownloadLayersFor and drops
 // the corresponding layer handles. Layers registered via AddLayer from outside a download
 // (for example pack's create-builder-scratch artifacts) are left alone.
@@ -531,9 +538,7 @@ func (s *Store) cleanupDownloadDirs() {
 		_ = os.RemoveAll(dir)
 	}
 	s.downloadDirs = nil
-	for _, id := range s.downloadedDiffIDs {
-		delete(s.onDiskLayersByDiffID, id)
-	}
+	s.dropDownloadedLayerHandles(s.downloadedDiffIDs)
 	s.downloadedDiffIDs = nil
 	// Allow a future ensureLayers() to re-download if needed.
 	s.downloadOnce = &sync.Once{}

--- a/local/store_download_cleanup_test.go
+++ b/local/store_download_cleanup_test.go
@@ -58,6 +58,26 @@ func TestCleanupDownloadDirs(t *testing.T) {
 	}
 }
 
+func TestPartialDownloadDropsLayerHandles(t *testing.T) {
+	s := NewStore(nil)
+
+	downloadedID := v1.Hash{Algorithm: "sha256", Hex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	keptID := v1.Hash{Algorithm: "sha256", Hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+	s.onDiskLayersByDiffID[downloadedID] = annotatedLayer{}
+	s.onDiskLayersByDiffID[keptID] = annotatedLayer{}
+
+	// Simulate AddLayer succeeding for the first extracted layer, then a later
+	// layer failing before downloadedDiffIDs is updated.
+	s.dropDownloadedLayerHandles([]v1.Hash{downloadedID})
+
+	if _, ok := s.onDiskLayersByDiffID[downloadedID]; ok {
+		t.Fatal("expected layer from a failed download to be dropped")
+	}
+	if _, ok := s.onDiskLayersByDiffID[keptID]; !ok {
+		t.Fatal("expected unrelated layer handle to be kept")
+	}
+}
+
 func TestCleanupDownloadDirsNoopWhenEmpty(t *testing.T) {
 	s := NewStore(nil)
 	// Should not panic or reset state when nothing was downloaded.

--- a/local/store_download_cleanup_test.go
+++ b/local/store_download_cleanup_test.go
@@ -1,0 +1,68 @@
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestCleanupDownloadDirs(t *testing.T) {
+	s := NewStore(nil)
+
+	downloadDir, err := os.MkdirTemp("", "imgutil.local.image.")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	// A second dir that simulates a pack/builder-owned layer path (must not be removed).
+	otherDir, err := os.MkdirTemp("", "create-builder-scratch")
+	if err != nil {
+		t.Fatalf("MkdirTemp other: %v", err)
+	}
+	defer os.RemoveAll(otherDir)
+
+	marker := filepath.Join(downloadDir, "layer.tar")
+	if err := os.WriteFile(marker, []byte("layer-bytes"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	otherFile := filepath.Join(otherDir, "new-layer.tar")
+	if err := os.WriteFile(otherFile, []byte("new-layer"), 0o600); err != nil {
+		t.Fatalf("WriteFile other: %v", err)
+	}
+
+	downloadedID := v1.Hash{Algorithm: "sha256", Hex: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+	keptID := v1.Hash{Algorithm: "sha256", Hex: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+
+	s.downloadDirs = []string{downloadDir}
+	s.downloadedDiffIDs = []v1.Hash{downloadedID}
+	s.onDiskLayersByDiffID[downloadedID] = annotatedLayer{}
+	s.onDiskLayersByDiffID[keptID] = annotatedLayer{}
+
+	s.cleanupDownloadDirs()
+
+	if _, err := os.Stat(downloadDir); !os.IsNotExist(err) {
+		t.Fatalf("expected download dir to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(otherFile); err != nil {
+		t.Fatalf("intentional cache/artifact path should remain: %v", err)
+	}
+	if _, ok := s.onDiskLayersByDiffID[downloadedID]; ok {
+		t.Fatal("expected downloaded layer handle to be dropped")
+	}
+	if _, ok := s.onDiskLayersByDiffID[keptID]; !ok {
+		t.Fatal("expected non-download layer handle to be kept")
+	}
+	if len(s.downloadDirs) != 0 || len(s.downloadedDiffIDs) != 0 {
+		t.Fatal("expected download tracking slices to be cleared")
+	}
+}
+
+func TestCleanupDownloadDirsNoopWhenEmpty(t *testing.T) {
+	s := NewStore(nil)
+	// Should not panic or reset state when nothing was downloaded.
+	s.cleanupDownloadDirs()
+	if s.downloadOnce == nil {
+		t.Fatal("downloadOnce should remain usable")
+	}
+}


### PR DESCRIPTION
## Summary

When a daemon rejects sparse/omit-base-layer image loads (notably **podman**), `doDownloadLayersFor` extracts the image under `/tmp/imgutil.local.image.*` so base layers can be re-sent. Those directories were never removed, so repeated `pack build` runs left large trees in `/tmp`.

### Changes

- Track extract dirs created during download
- After `Save` / `SaveFile` consume the layers, remove those dirs (`defer` cleanup)
- On download failure, remove the extract dir immediately
- Drop only layer handles from that download; layers registered via `AddLayer` from caller-owned paths (e.g. pack builder scratch) are left alone
- Reset `downloadOnce` so a later `ensureLayers` can re-download if needed

Daemon image cache and intentional pack caches are not touched.

## Test plan

- [x] `go test ./local/ -run TestCleanupDownloadDirs`
- [ ] With podman: run `pack build` twice and confirm `/tmp/imgutil.local.image.*` does not accumulate
- [ ] Docker sparse omit-base path still works

Fixes buildpacks/pack#1167