### PR TITLE
Fix local facade layer digests

### DIFF
--- a/local/v1_facade.go
+++ b/local/v1_facade.go
@@ -240,7 +240,8 @@ func (l *v1LayerFacade) DiffID() (v1.Hash, error) {
 }
 
 func (l *v1LayerFacade) Digest() (v1.Hash, error) {
-	return v1.Hash{}, nil
+	// Local images are written as uncompressed tar layers, so their digest is their diff ID.
+	return l.diffID, nil
 }
 
 func (l *v1LayerFacade) Uncompressed() (io.ReadCloser, error) {

--- a/local/v1_facade_test.go
+++ b/local/v1_facade_test.go
@@ -1,0 +1,60 @@
+package local
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/buildpacks/imgutil"
+)
+
+func TestImageFromPreservesDistinctLayers(t *testing.T) {
+	first, err := v1.NewHash("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := v1.NewHash("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image, err := imageFrom([]v1.Layer{
+		facadeLayer(first, "first"),
+		facadeLayer(second, "second"),
+	}, &v1.ConfigFile{RootFS: v1.RootFS{Type: "layers"}}, imgutil.DockerTypes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layers, err := image.Layers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layers) != 2 {
+		t.Fatalf("got %d layers, want 2", len(layers))
+	}
+
+	for index, expected := range []v1.Hash{first, second} {
+		actual, err := layers[index].DiffID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual != expected {
+			t.Errorf("layer %d has diff ID %q, want %q", index, actual, expected)
+		}
+	}
+}
+
+func facadeLayer(diffID v1.Hash, contents string) *v1LayerFacade {
+	return &v1LayerFacade{
+		diffID: diffID,
+		uncompressed: func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewBufferString(contents)), nil
+		},
+		uncompressedSize: func() (int64, error) {
+			return int64(len(contents)), nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- return the known diff ID as the digest for uncompressed local facade layers
- preserve distinct inherited layers when go-containerregistry resolves them by digest

## Testing
- `GOWORK=off go test ./local -run TestImageFromPreservesDistinctLayers -count=1`
- Pack Spring Boot daemon-export reproduction with Docker Desktop classic image storage (`overlay2`)
- pushed result to a fresh local registry and verified all 21 layer diff IDs (`mismatch_count=0`)
- repeated equivalent registry validation with Docker Desktop containerd image storage (`mismatch_count=0`)

This, I believe, will fix the underlying issue that caused https://github.com/buildpacks/lifecycle/issues/1662 and the regression.