### PR TITLE
fix: preserve the original index media type when replacing a manifest

### DIFF
--- a/cnb_index.go
+++ b/cnb_index.go
@@ -168,7 +168,27 @@ func (h *CNBIndex) replaceDescriptor(digest name.Digest, withFun func(descriptor
 	if err != nil {
 		return err
 	}
-	mediaType := desc.MediaType
+	// Capture the index's own media type before mutating it below, so it can be
+	// restored afterwards. This must go through IndexManifest(), not
+	// h.ImageIndex.MediaType(): for an index freshly loaded from an OCI layout
+	// directory, go-containerregistry's layoutIndex.MediaType() hardcodes
+	// types.OCIImageIndex regardless of what index.json actually says, so it
+	// misreports a Docker manifest list as OCI. IndexManifest() parses the raw
+	// JSON and reflects the real value. desc.MediaType (the prior source) was a
+	// second bug on top: that's the per-manifest entry's *image* media type,
+	// never an *index* type, so it could never equal the post-mutation index
+	// media type below, and "restoring" to it left the index as neither OCI nor
+	// the original Docker type.
+	indexManifestBefore, err := getIndexManifest(h.ImageIndex)
+	if err != nil {
+		return err
+	}
+	mediaType := indexManifestBefore.MediaType
+	if mediaType == "" {
+		// The OCI Image Layout spec allows index.json to omit "mediaType"; per
+		// the spec, an absent value means an OCI Image Index.
+		mediaType = types.OCIImageIndex
+	}
 	if desc.Platform == nil {
 		desc.Platform = &v1.Platform{}
 	}

--- a/cnb_index_test.go
+++ b/cnb_index_test.go
@@ -1,0 +1,105 @@
+package imgutil_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"github.com/buildpacks/imgutil"
+)
+
+// TestCNBIndexSetAnnotationsPreservesMediaType is a regression test: replaceDescriptor
+// (shared by SetOS, SetArchitecture, SetVariant, and SetAnnotations) used to compare a
+// manifest entry's *image* media type against the index's own media type to decide
+// whether to restore it after mutating the index - those are never equal, so an OCI
+// index always ended up rewritten with a media type that was neither OCI nor Docker,
+// and downstream code that checks for exactly types.OCIImageIndex treated it as Docker.
+func TestCNBIndexSetAnnotationsPreservesMediaType(t *testing.T) {
+	for _, test := range []struct {
+		name              string
+		mediaType         types.MediaType
+		expectedMediaType types.MediaType
+	}{
+		{
+			name:              "oci index",
+			expectedMediaType: types.OCIImageIndex,
+		},
+		{
+			name:              "docker index",
+			mediaType:         types.DockerManifestList,
+			expectedMediaType: types.DockerManifestList,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repoName := "some/index"
+
+			index, err := imgutil.NewCNBIndex(repoName, imgutil.IndexOptions{
+				MediaType: test.mediaType,
+				LayoutIndexOptions: imgutil.LayoutIndexOptions{
+					XdgPath: tmpDir,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			image, err := random.Image(1024, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			index.AddManifest(image)
+
+			hash, err := image.Digest()
+			if err != nil {
+				t.Fatal(err)
+			}
+			digest, err := name.NewDigest(fmt.Sprintf("random@%s", hash.String()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := index.SetAnnotations(digest, map[string]string{"some-key": "some-value"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := index.SaveDir(); err != nil {
+				t.Fatal(err)
+			}
+
+			indexManifest := readIndexManifest(t, tmpDir, repoName)
+			if diff := cmp.Diff(test.expectedMediaType, indexManifest.MediaType); diff != "" {
+				t.Fatalf("unexpected index media type (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(1, len(indexManifest.Manifests)); diff != "" {
+				t.Fatalf("unexpected manifest count (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff("some-value", indexManifest.Manifests[0].Annotations["some-key"]); diff != "" {
+				t.Fatalf("unexpected manifest annotation (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func readIndexManifest(t *testing.T, tmpDir, repoName string) v1.IndexManifest {
+	t.Helper()
+
+	rawIndex, err := os.ReadFile(filepath.Join(tmpDir, imgutil.MakeFileSafeName(repoName), "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var indexManifest v1.IndexManifest
+	if err := json.Unmarshal(rawIndex, &indexManifest); err != nil {
+		t.Fatal(err)
+	}
+
+	return indexManifest
+}

--- a/layout/index_test.go
+++ b/layout/index_test.go
@@ -367,6 +367,17 @@ func testIndex(t *testing.T, when spec.G, it spec.S) {
 								h.AssertEq(t, len(index.Manifests[1].Annotations), 8)
 								h.AssertEq(t, index.Manifests[1].Annotations["some-key"], "some-value")
 							})
+
+							it("index media-type stays OCI after updating a manifest", func() {
+								annotations := map[string]string{
+									"some-key": "some-value",
+								}
+								h.AssertNil(t, idx.SetAnnotations(digest1, annotations))
+								h.AssertNil(t, idx.SaveDir())
+
+								index := h.ReadIndexManifest(t, localPath)
+								h.AssertEq(t, index.MediaType, types.OCIImageIndex)
+							})
 						})
 
 						when("docker media-type is used", func() {


### PR DESCRIPTION
Related to buildpacks/pack#2679 (`pack manifest annotate` converts an OCI image index to a Docker manifest list). The root cause is here in `imgutil`, in `CNBIndex.replaceDescriptor` - the shared helper behind `SetOS`, `SetArchitecture`, `SetVariant`, and `SetAnnotations`.

### What's broken

`replaceDescriptor` tries to preserve the index's media type across the `mutate.RemoveManifests`/`mutate.AppendManifests` round-trip it does to swap in the updated descriptor:

```go
mediaType := desc.MediaType
// ... mutate h.ImageIndex ...
mediaTypeAfter, err := h.ImageIndex.MediaType()
if mediaTypeAfter != mediaType {
    h.ImageIndex = mutate.IndexMediaType(h.ImageIndex, mediaType)
}
```

`desc` here is the descriptor of the single manifest entry being replaced, so `desc.MediaType` is an *image* manifest media type (e.g. `application/vnd.oci.image.manifest.v1+json`), never an *index* media type (`application/vnd.oci.image.index.v1+json` / `.../manifest.list.v2+json`). Those two families never compare equal, so the "restore" branch always fires, and it stamps the *index* with an *image* media type. The result is never `types.OCIImageIndex`, so every downstream `indexType == types.OCIImageIndex` check (e.g. `newEmptyLayoutPath` in `SaveDir`) takes the non-OCI branch - an OCI-format index always gets written back out as a Docker manifest list after any `Set*` call.

There's a second, independent bug that made this hard to spot by only checking `h.ImageIndex.MediaType()` before the mutation: for an index freshly loaded from an OCI layout directory, go-containerregistry's `layoutIndex.MediaType()` unconditionally returns `types.OCIImageIndex` and never looks at `index.json`'s actual `"mediaType"` field:

```go
// go-containerregistry pkg/v1/layout/index.go
func (l Path) ImageIndex() (v1.ImageIndex, error) {
	...
	idx := &layoutIndex{
		mediaType: types.OCIImageIndex,
		...
	}
	return idx, nil
}
```

So a Docker-format base index would be misreported as OCI at the very first read, before any mutation. `IndexManifest()` (which unmarshals the raw JSON) doesn't have this problem - `v1.IndexManifest.MediaType` reflects what's actually on disk.

### Fix

Source the "original" media type from `IndexManifest().MediaType` instead of `desc.MediaType`, and fall back to `types.OCIImageIndex` if it's empty (an omitted `mediaType` in an OCI layout `index.json` means OCI, per spec). This is correct both for the freshly-loaded case (reads the real on-disk value, sidestepping the `layoutIndex.MediaType()` bug above) and for a chain of `Set*` calls on an already-mutated index (`mutate.index.IndexManifest().MediaType` is set consistently with `.MediaType()`, so it keeps reflecting whatever was last correctly restored).

### Testing

Added a test asserting the index media type stays `types.OCIImageIndex` after `SetAnnotations`, next to the existing (already-passing, coincidentally passing for reasons unrelated to correctness - see above) Docker-media-type coverage in the same block. `go build`, `go vet`, and `go test ./...` all pass; the `local`/`remote` package failures I see locally are pre-existing and unrelated (host-architecture and registry-network flakiness in a sandbox without a matching Docker daemon - confirmed present on `main` without this change too).

### AI disclosure

Used Claude Code (Anthropic) to investigate the underlying `pack` issue, trace it to this repo, implement the fix, and write the accompanying test, under my direction and review.